### PR TITLE
Add blog posts for Tailscale/WSL2 SSH and Claude Terminal gists

### DIFF
--- a/_posts/2026-03-28-claude-terminal-profile.md
+++ b/_posts/2026-03-28-claude-terminal-profile.md
@@ -1,0 +1,33 @@
+---
+title: 'Windows Terminal profile for Claude with no permission prompts'
+date: 2026-03-28
+venue-type: blog
+permalink: /posts/2026/03/claude-terminal-profile/
+tags:
+  - blog-post
+  - tooling
+---
+
+Every time I open Claude Code in a new directory I get a workspace trust prompt asking me to approve permissions. It makes sense as a safety guardrail, but in directories I own and trust it's just friction. I made a dedicated Windows Terminal profile that launches Claude with `--permission-mode bypassPermissions` so it skips straight to work.
+
+Here's the gist: [Windows Terminal profile for Claude](https://gist.github.com/bstee615/9b43dd9e40f91f0f082f5697968f04b3).
+
+You can install it with a PowerShell one-liner:
+
+```powershell
+irm 'https://gist.githubusercontent.com/bstee615/9b43dd9e40f91f0f082f5697968f04b3/raw/setup.ps1' | iex
+```
+
+Or add this manually to `profiles.list` in your Windows Terminal `settings.json` (`Ctrl+,` → **Open JSON file**):
+
+```json
+{
+    "commandline": "cmd.exe /c claude --permission-mode bypassPermissions",
+    "guid": "{a1b2c3d4-e5f6-7890-abcd-ef1234567890}",
+    "hidden": false,
+    "name": "Claude",
+    "startingDirectory": "%USERPROFILE%"
+}
+```
+
+The setup script checks for an existing profile by GUID before inserting, so running it twice is safe. One caveat: only use this flag in directories you own or fully trust — it disables all permission checks.

--- a/_posts/2026-03-28-tailscale-wsl2-ssh.md
+++ b/_posts/2026-03-28-tailscale-wsl2-ssh.md
@@ -1,0 +1,45 @@
+---
+title: 'Tailscale + SSH setup for Windows + WSL2'
+date: 2026-03-28
+venue-type: blog
+permalink: /posts/2026/03/tailscale-wsl2-ssh/
+tags:
+  - blog-post
+  - tooling
+---
+
+I do a lot of work from my phone while away from my desk and wanted a clean way to SSH into my Windows machine and drop into whichever WSL2 distro I needed. The tricky part: iOS Tailscale intercepts port 22, WSL2 distros share a network namespace so you can't run independent sshd instances on the same port, and adding a Tailscale node per distro causes TUN device conflicts.
+
+The solution I landed on was running a single Windows OpenSSH server on three ports — 2222 for PowerShell, 2223 for Debian, 2224 for Alpine — and using `Match LocalPort` directives in `sshd_config` to forward each port to the right WSL distro via `wsl.exe`. One Tailscale node on Windows handles all the routing.
+
+# TL;DR
+
+See the gist: [Tailscale + SSH setup for Windows + WSL2](https://gist.github.com/bstee615/d510992d535e955fb175028eb5c5c4d0).
+
+The key bit in `sshd_config`:
+
+```
+Port 2222
+Port 2223
+Port 2224
+
+Match LocalPort 2223
+       ForceCommand C:\Windows\System32\wsl.exe -d Debian --cd ~
+
+Match LocalPort 2224
+       ForceCommand C:\Windows\System32\wsl.exe -d Alpine --cd ~
+```
+
+Then connect with:
+
+| Command | Destination |
+|---------|-------------|
+| `ssh -p 2222 myuser@zap` | Windows PowerShell |
+| `ssh -p 2223 myuser@zap` | Debian bash |
+| `ssh -p 2224 myuser@zap` | Alpine sh |
+
+# How it works
+
+Everything boots automatically. Windows starts Tailscale and sshd as services. Alpine's `wsl.conf` runs a startup script that brings up dockerd and any other services I need. Debian uses systemd. No manual intervention needed after a reboot.
+
+The gist covers the full setup: Tailscale auth, ACL policy, sshd configuration, firewall rules, and the WSL startup scripts. I save the three SSH commands as profiles in Termius for one-tap access from my phone.


### PR DESCRIPTION
## Summary
- Adds `2026-03-28-tailscale-wsl2-ssh.md`: blog post for the [Tailscale + SSH setup for Windows + WSL2](https://gist.github.com/bstee615/d510992d535e955fb175028eb5c5c4d0) gist
- Adds `2026-03-28-claude-terminal-profile.md`: blog post for the [Windows Terminal profile for Claude](https://gist.github.com/bstee615/9b43dd9e40f91f0f082f5697968f04b3) gist

Both posts follow the existing style (casual intro, TL;DR/gist link, code snippets, `venue-type: blog` frontmatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)