### PR TITLE
Optimize runtime and mobile interactions

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -142,309 +142,7 @@ const pageSlide = {
       <span>My opinions are my own.</span>
       <span>Powered by <a href="https://astro.build/">Astro</a> and <a href="https://pages.github.com/">GitHub Pages</a>.</span>
     </footer>
-    <script is:inline>
-      const themeToggle = document.querySelector("#theme-toggle");
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
-      const getSavedTheme = () => {
-        const value = document.cookie
-          .split("; ")
-          .find((cookie) => cookie.startsWith("site-theme="))
-          ?.split("=")[1];
-        return value === "pastel-dark" || value === "pastel-light"
-          ? value
-          : undefined;
-      };
-      const applyThemeLabel = () => {
-        const isDark = document.documentElement.dataset.theme === "pastel-dark";
-        themeToggle?.setAttribute("aria-label", `Switch to ${isDark ? "light" : "dark"} mode`);
-      };
-      const applySystemTheme = () => {
-        if (getSavedTheme()) return;
-
-        document.documentElement.dataset.theme = systemTheme.matches
-          ? "pastel-dark"
-          : "pastel-light";
-        applyThemeLabel();
-      };
-
-      window.siteThemePreferenceCleanup?.();
-      systemTheme.addEventListener("change", applySystemTheme);
-      window.siteThemePreferenceCleanup = () => {
-        systemTheme.removeEventListener("change", applySystemTheme);
-      };
-      applySystemTheme();
-      applyThemeLabel();
-      if (themeToggle) themeToggle.onclick = () => {
-        const nextTheme = document.documentElement.dataset.theme === "pastel-dark"
-          ? "pastel-light"
-          : "pastel-dark";
-        document.documentElement.dataset.theme = nextTheme;
-        const secureCookie = window.location.protocol === "https:" ? "; Secure" : "";
-        document.cookie = `site-theme=${nextTheme}; Path=/; Max-Age=31536000; SameSite=Lax${secureCookie}`;
-        applyThemeLabel();
-      };
-
-      const transitionPageOrder = new Map([
-        ["/", 0],
-        ["/cv/", 1],
-        ["/writing/", 2],
-      ]);
-      const isDetailPage = (pathname) =>
-        /^\/(?:publication|writing)\/[^/]+\/?$/.test(pathname);
-      const isMainPage = (pathname) =>
-        transitionPageOrder.has(pathname) || pathname === "/publications/";
-      let transitionObserver;
-      let pendingDetailBackTarget;
-
-      const pageLabel = () => {
-        const label = document.title.replace(/ · Benjamin Steenhoek$/, "");
-        return label === "Benjamin Steenhoek" ? "Home" : label;
-      };
-
-      const saveCurrentScrollPosition = () => {
-        history.replaceState(
-          {
-            ...(history.state ?? {}),
-            scrollX: window.scrollX,
-            scrollY: window.scrollY,
-          },
-          "",
-        );
-      };
-
-      const restoreCurrentScrollPosition = () => {
-        const { scrollX, scrollY } = history.state ?? {};
-        if (!Number.isFinite(scrollX) || !Number.isFinite(scrollY)) return;
-
-        const previousScrollBehavior = document.documentElement.style.scrollBehavior;
-        document.documentElement.style.scrollBehavior = "auto";
-        window.scrollTo(scrollX, scrollY);
-        window.requestAnimationFrame(() => {
-          document.documentElement.style.scrollBehavior = previousScrollBehavior;
-        });
-      };
-
-      const configureDetailBackButton = () => {
-        const button = document.querySelector("[data-detail-back]");
-        if (!(button instanceof HTMLAnchorElement)) return;
-
-        const fallback = window.location.pathname.startsWith("/publication/")
-          ? { href: "/publications/", label: "Publications" }
-          : { href: "/writing/", label: "Blog" };
-        const isDetail = isDetailPage(window.location.pathname);
-        const target = history.state?.siteDetailBackTarget;
-        const label = button.querySelector("[data-detail-back-label]");
-        button.hidden = !isDetail;
-        if (!isDetail) return;
-
-        if (!target || target.destination !== window.location.href) {
-          button.href = fallback.href;
-          button.setAttribute("aria-label", `Back to ${fallback.label}`);
-          if (label) label.textContent = `Back to ${fallback.label}`;
-          return;
-        }
-
-        button.href = target.href;
-        button.setAttribute("aria-label", `Back to ${target.label}`);
-        if (label) label.textContent = `Back to ${target.label}`;
-        if (button.dataset.detailBackBound === "true") return;
-        button.dataset.detailBackBound = "true";
-        button.addEventListener("click", (event) => {
-          const currentTarget = history.state?.siteDetailBackTarget;
-          if (!currentTarget || currentTarget.destination !== window.location.href) return;
-
-          event.preventDefault();
-          history.back();
-        });
-      };
-
-      const configureScrollTopButton = () => {
-        const button = document.querySelector("[data-scroll-top]");
-        if (!(button instanceof HTMLButtonElement)) return;
-
-        const updateVisibility = () => {
-          button.hidden = window.scrollY <= 1;
-        };
-
-        if (button.dataset.scrollTopBound !== "true") {
-          button.dataset.scrollTopBound = "true";
-          button.addEventListener("click", () => {
-            window.scrollTo({ top: 0, behavior: "smooth" });
-          });
-          window.addEventListener("scroll", updateVisibility, { passive: true });
-        }
-        updateVisibility();
-      };
-
-      const writeClipboardText = async (text) => {
-        if (navigator.clipboard?.writeText) {
-          try {
-            await navigator.clipboard.writeText(text);
-            return;
-          } catch (error) {
-            console.warn("Clipboard API unavailable; using selection fallback", error);
-          }
-        }
-
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.append(textarea);
-        textarea.select();
-        const copied = document.execCommand("copy");
-        textarea.remove();
-        if (!copied) throw new Error("Browser rejected the clipboard copy command");
-      };
-
-      const configureCodeCopyButtons = () => {
-        document.querySelectorAll(".body pre").forEach((pre) => {
-          if (!(pre instanceof HTMLElement) || pre.closest(".code-sample")) return;
-
-          const code = pre.querySelector("code");
-          if (!code) return;
-
-          const wrapper = document.createElement("div");
-          wrapper.className = "code-sample";
-          pre.before(wrapper);
-          wrapper.append(pre);
-
-          const button = document.createElement("button");
-          button.className = "copy-code-button btn btn-secondary btn-xs";
-          button.type = "button";
-          button.textContent = "Copy";
-          button.setAttribute("aria-label", "Copy code sample");
-          wrapper.append(button);
-
-          button.addEventListener("click", async () => {
-            try {
-              await writeClipboardText(code.textContent ?? "");
-              button.textContent = "Copied";
-              button.setAttribute("aria-label", "Code sample copied");
-              window.setTimeout(() => {
-                button.textContent = "Copy";
-                button.setAttribute("aria-label", "Copy code sample");
-              }, 1800);
-            } catch (error) {
-              console.error("Could not copy code sample", error);
-              button.textContent = "Copy failed";
-              button.setAttribute("aria-label", "Code sample could not be copied");
-            }
-          });
-        });
-      };
-
-      const finishTransitionScroll = () => {
-        if (document.documentElement.hasAttribute("data-astro-transition")) return;
-
-        transitionObserver?.disconnect();
-        transitionObserver = undefined;
-        delete document.documentElement.dataset.transitionScroll;
-      };
-
-      const configurePageTransitions = () => {
-        document.querySelectorAll("a[href]").forEach((link) => {
-          if (!(link instanceof HTMLAnchorElement)) return;
-
-          const target = new URL(link.href, window.location.href);
-          if (target.origin !== window.location.origin) return;
-
-          const isHeaderLink = Boolean(link.closest(".site-header"));
-          const isSlideNavigation = link.hasAttribute("data-slide-navigation");
-          const isTransitionPage = transitionPageOrder.has(target.pathname);
-          const isDetailNavigation =
-            isDetailPage(target.pathname) ||
-            (isDetailPage(window.location.pathname) && isMainPage(target.pathname));
-          const isCurrentPage =
-            target.pathname === window.location.pathname &&
-            target.search === window.location.search;
-
-          if (
-            ((isHeaderLink && isTransitionPage) || isSlideNavigation || isDetailNavigation) &&
-            !isCurrentPage
-          ) {
-            delete link.dataset.astroReload;
-          } else {
-            link.dataset.astroReload = "";
-          }
-        });
-      };
-
-      configurePageTransitions();
-      configureDetailBackButton();
-      configureScrollTopButton();
-      configureCodeCopyButtons();
-      window.addEventListener("pagehide", saveCurrentScrollPosition);
-      window.addEventListener("pageshow", restoreCurrentScrollPosition);
-      document.addEventListener("astro:page-load", () => {
-        configurePageTransitions();
-        configureDetailBackButton();
-        configureScrollTopButton();
-        configureCodeCopyButtons();
-      });
-      document.addEventListener("astro:before-preparation", (event) => {
-        saveCurrentScrollPosition();
-
-        const isPageChange =
-          event.from.pathname !== event.to.pathname ||
-          event.from.search !== event.to.search;
-        if (isPageChange) {
-          document.documentElement.dataset.transitionScroll = "instant";
-        }
-
-        const fromIsDetail = isDetailPage(event.from.pathname);
-        const toIsDetail = isDetailPage(event.to.pathname);
-        if (toIsDetail) {
-          pendingDetailBackTarget = {
-            destination: event.to.href,
-            href: event.from.href,
-            label: pageLabel(),
-          };
-          event.direction = "forward";
-          return;
-        }
-        if (fromIsDetail && isMainPage(event.to.pathname)) {
-          event.direction = "back";
-          return;
-        }
-
-        const sourceElement = event.sourceElement;
-        if (!(sourceElement instanceof Element) || !sourceElement.closest(".site-header")) return;
-        const fromIndex = transitionPageOrder.get(event.from.pathname);
-        const toIndex = transitionPageOrder.get(event.to.pathname);
-        if (fromIndex === undefined || toIndex === undefined || fromIndex === toIndex) return;
-
-        event.direction = toIndex < fromIndex ? "back" : "forward";
-      });
-      document.addEventListener("astro:before-swap", (event) => {
-        event.newDocument.documentElement.dataset.theme =
-          document.documentElement.dataset.theme;
-        if (document.documentElement.dataset.transitionScroll === "instant") {
-          event.newDocument.documentElement.dataset.transitionScroll = "instant";
-        }
-      });
-      document.addEventListener("astro:after-swap", () => {
-        if (
-          pendingDetailBackTarget &&
-          pendingDetailBackTarget.destination === window.location.href
-        ) {
-          history.replaceState(
-            { ...history.state, siteDetailBackTarget: pendingDetailBackTarget },
-            "",
-          );
-        }
-        pendingDetailBackTarget = undefined;
-        configureDetailBackButton();
-        configureScrollTopButton();
-        transitionObserver?.disconnect();
-        transitionObserver = new MutationObserver(finishTransitionScroll);
-        transitionObserver.observe(document.documentElement, {
-          attributes: true,
-          attributeFilter: ["data-astro-transition"],
-        });
-        finishTransitionScroll();
-      });
-    </script>
+    <script src="../scripts/site.ts"></script>
   </body>
 </html>
 
@@ -492,6 +190,7 @@ const pageSlide = {
   a {
     color: var(--accent);
     font-weight: 650;
+    overflow-wrap: anywhere;
     text-decoration-line: underline;
     text-decoration-color: color-mix(in srgb, currentColor 55%, transparent);
     text-decoration-thickness: 0.08em;
@@ -522,7 +221,6 @@ const pageSlide = {
       transform 140ms ease;
   }
 
-  a.btn.btn-secondary:hover,
   a.btn.btn-secondary:focus-visible {
     border-color: color-mix(in oklch, var(--color-secondary) 90%, var(--color-secondary-content));
     color: var(--color-secondary-content);
@@ -555,6 +253,10 @@ const pageSlide = {
     max-width: 100%;
   }
 
+  img {
+    height: auto;
+  }
+
   h1,
   h2,
   h3,
@@ -564,7 +266,9 @@ const pageSlide = {
 
   h1,
   h2,
-  h3 {
+  h3,
+  h4 {
+    overflow-wrap: anywhere;
     line-height: 1.08;
   }
 
@@ -586,6 +290,16 @@ const pageSlide = {
   .body :is(h2, h3, h4) {
     scroll-margin-top: 7rem;
     text-wrap: balance;
+  }
+
+  .body {
+    min-width: 0;
+  }
+
+  .body pre {
+    max-width: 100%;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
   }
 
   .body h2 {
@@ -796,7 +510,6 @@ const pageSlide = {
       background-color 160ms ease;
   }
 
-  .header-control:hover,
   .header-control:focus-visible {
     background: color-mix(in oklch, var(--accent) 12%, transparent);
   }
@@ -843,7 +556,6 @@ const pageSlide = {
       visibility 0s linear 220ms;
   }
 
-  .header-control:hover span,
   .header-control:focus-visible span {
     clip-path: inset(0 0 0 0 round var(--radius-field));
     opacity: 1;
@@ -980,10 +692,6 @@ const pageSlide = {
     transition: transform 180ms ease;
   }
 
-  .publication-card__visual:hover {
-    transform: translateY(-4px) rotate(-0.4deg);
-  }
-
   .publication-card__content h3 {
     margin: 0.7rem 0 1.1rem;
     font-family: var(--font-sans);
@@ -1024,27 +732,61 @@ const pageSlide = {
     }
 
     .site-header__inner {
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 0.65rem;
+      display: grid;
+      grid-template-areas:
+        "identity theme"
+        "nav nav";
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 0.25rem 0.5rem;
+      padding: 0.65rem 0;
+    }
+
+    .site-identity {
+      grid-area: identity;
+    }
+
+    .wordmark {
+      font-size: 1.05rem;
+      white-space: nowrap;
     }
 
     .nav-actions {
-      width: 100%;
-      align-items: center;
-      justify-content: space-between;
+      display: contents;
+    }
+
+    #theme-toggle {
+      --btn-height: 2.75rem;
+      grid-area: theme;
+    }
+
+    .header-control {
+      width: 2.75rem;
+      min-width: 2.75rem;
+      max-width: 2.75rem;
+      min-height: 2.75rem;
     }
 
     .site-header nav {
-      gap: 0.65rem;
+      grid-area: nav;
+      justify-content: space-between;
+      gap: 0.2rem;
     }
 
     .site-header nav a {
-      font-size: 0.72rem;
+      display: inline-flex;
+      min-width: 2.75rem;
+      min-height: 2.75rem;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.68rem;
     }
 
     .nav-separator {
-      height: 1rem;
+      display: none;
+    }
+
+    .btn {
+      min-height: 2.75rem;
     }
 
     .section-heading,
@@ -1059,6 +801,64 @@ const pageSlide = {
 
     .publication-card--reverse .publication-card__visual {
       order: initial;
+    }
+
+    .site-header:has([data-detail-back]:not([hidden])) .wordmark {
+      display: none;
+    }
+  }
+
+  @media (min-width: 520px) and (max-width: 760px) and (max-height: 500px) {
+    .site-header__inner {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0.5rem 0;
+    }
+
+    .site-identity,
+    #theme-toggle,
+    .site-header nav {
+      grid-area: auto;
+    }
+
+    .nav-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .site-header nav {
+      gap: 0.3rem;
+    }
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    a.btn.btn-secondary:hover {
+      border-color: color-mix(in oklch, var(--color-secondary) 90%, var(--color-secondary-content));
+      color: var(--color-secondary-content);
+      background-color: color-mix(in oklch, var(--color-secondary) 90%, var(--color-secondary-content));
+      transform: translateY(-1px);
+    }
+
+    .header-control:hover {
+      background: color-mix(in oklch, var(--accent) 12%, transparent);
+    }
+
+    .header-control:hover span {
+      clip-path: inset(0 0 0 0 round var(--radius-field));
+      opacity: 1;
+      transform: translate(0, -50%);
+      visibility: visible;
+      transition-delay: 0s;
+    }
+
+    .publication-card__visual:hover {
+      transform: translateY(-4px) rotate(-0.4deg);
+    }
+  }
+
+  @media (hover: none) {
+    .header-control span {
+      display: none;
     }
   }
 

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -52,7 +52,7 @@ const highlightName = (citation: string) =>
           </article>
         ))}
       </div>
-      <details data-animated-details>
+      <details>
         <summary>More professional experience</summary>
         <div class="details-content">
           <div class="details-content__inner">
@@ -112,7 +112,7 @@ const highlightName = (citation: string) =>
           </li>
         ))}
       </ol>
-      <details data-animated-details>
+      <details>
         <summary>More publications</summary>
         <div class="details-content">
           <div class="details-content__inner">
@@ -230,42 +230,31 @@ const highlightName = (citation: string) =>
   }
 
   summary {
+    display: flex;
+    min-height: 2.75rem;
+    align-items: center;
     cursor: pointer;
     color: var(--accent);
     font-weight: 800;
+    touch-action: manipulation;
   }
 
-  .details-content {
-    display: grid;
-    grid-template-rows: 0fr;
-    opacity: 0;
-    transition:
-      grid-template-rows 320ms cubic-bezier(0.22, 1, 0.36, 1),
-      opacity 200ms ease;
-  }
-
-  details.is-open > .details-content {
-    grid-template-rows: 1fr;
-    opacity: 1;
-  }
-
-  details.is-closing > .details-content {
-    grid-template-rows: 0fr;
-    opacity: 0;
-  }
-
-  .details-content__inner {
-    min-height: 0;
-    overflow: hidden;
+  details[open] > .details-content > .details-content__inner {
+    animation: details-reveal 180ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   .details-content :where(.cv-entries, .cv-publications) {
     margin-top: 1rem;
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .details-content {
-      transition: none;
+  @keyframes details-reveal {
+    from {
+      opacity: 0;
+      transform: translateY(-0.35rem);
+    }
+    to {
+      opacity: 1;
+      transform: none;
     }
   }
 
@@ -317,6 +306,19 @@ const highlightName = (citation: string) =>
       display: block;
       text-align: left;
     }
+
+    .cv-publications h3 {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .publication-links {
+      flex-wrap: wrap;
+    }
+
+    .publication-links .btn {
+      --btn-height: 2.5rem;
+    }
   }
 
   @media print {
@@ -344,57 +346,10 @@ const highlightName = (citation: string) =>
       break-after: avoid;
     }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    details[open] > .details-content > .details-content__inner {
+      animation: none;
+    }
+  }
 </style>
-
-<script is:inline>
-  document.querySelectorAll("details[data-animated-details]").forEach((detail) => {
-    const summary = detail.querySelector("summary");
-    const content = detail.querySelector(".details-content");
-    if (!summary || !content) return;
-
-    let closeTimer;
-    if (detail.open) detail.classList.add("is-open");
-
-    summary.addEventListener("click", (event) => {
-      event.preventDefault();
-      if (detail.classList.contains("is-closing")) {
-        window.clearTimeout(closeTimer);
-        detail.classList.remove("is-closing");
-        detail.classList.add("is-open");
-        return;
-      }
-
-      if (!detail.open) {
-        detail.open = true;
-        content.getBoundingClientRect();
-        window.requestAnimationFrame(() => detail.classList.add("is-open"));
-        return;
-      }
-
-      detail.classList.remove("is-open");
-      detail.classList.add("is-closing");
-      closeTimer = window.setTimeout(() => {
-        detail.open = false;
-        detail.classList.remove("is-closing");
-      }, 320);
-    });
-  });
-</script>
-
-<script>
-  let previouslyOpen = new WeakSet();
-
-  window.addEventListener("beforeprint", () => {
-    previouslyOpen = new WeakSet();
-    document.querySelectorAll("details").forEach((detail) => {
-      if (detail.open) previouslyOpen.add(detail);
-      detail.open = true;
-    });
-  });
-
-  window.addEventListener("afterprint", () => {
-    document.querySelectorAll("details").forEach((detail) => {
-      if (!previouslyOpen.has(detail)) detail.open = false;
-    });
-  });
-</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -311,10 +311,11 @@ const publicationsByYear = Array.from(
     scrollbar-color: var(--muted) transparent;
     scrollbar-gutter: stable;
     scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
   }
 
   .activity-scroll > li {
-    height: var(--activity-row-height);
+    min-height: var(--activity-row-height);
     box-sizing: border-box;
   }
 
@@ -552,6 +553,10 @@ const publicationsByYear = Array.from(
       display: flex;
       flex-wrap: wrap;
       gap: 1rem;
+    }
+
+    .publication-row__links .btn {
+      min-height: 2.75rem;
     }
   }
 

--- a/src/pages/posts/[year]/[month]/[slug].astro
+++ b/src/pages/posts/[year]/[month]/[slug].astro
@@ -30,8 +30,5 @@ const { target } = Astro.props;
   </head>
   <body>
     <p>Redirecting to <a href={target}>{target}</a>.</p>
-    <script is:inline define:vars={{ target }}>
-      window.location.replace(target);
-    </script>
   </body>
 </html>

--- a/src/pages/stream/[slug].astro
+++ b/src/pages/stream/[slug].astro
@@ -28,8 +28,5 @@ const { target } = Astro.props;
   </head>
   <body>
     <p>Redirecting to <a href={target}>{target}</a>.</p>
-    <script is:inline define:vars={{ target }}>
-      window.location.replace(target);
-    </script>
   </body>
 </html>

--- a/src/pages/writing/[id].astro
+++ b/src/pages/writing/[id].astro
@@ -125,9 +125,12 @@ const { Content } = await render(post);
   }
 
   .body :global(table) {
+    display: block;
     width: 100%;
+    max-width: 100%;
     margin: 1.75rem 0;
-    overflow: hidden;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
     border: 1px solid var(--line);
     border-collapse: separate;
     border-radius: var(--radius-field);
@@ -154,5 +157,20 @@ const { Content } = await render(post);
   .body :global(th + th),
   .body :global(td + td) {
     border-left: 1px solid var(--line);
+  }
+
+  @media (max-width: 600px) {
+    .body {
+      font-size: 1.08rem;
+    }
+
+    .body :global(th),
+    .body :global(td) {
+      padding: 0.6rem 0.75rem;
+    }
+
+    .body :global(.copy-code-button) {
+      --btn-height: 2.5rem;
+    }
   }
 </style>

--- a/src/scripts/site.ts
+++ b/src/scripts/site.ts
@@ -1,0 +1,348 @@
+import type {
+  TransitionBeforePreparationEvent,
+  TransitionBeforeSwapEvent,
+} from "astro:transitions/client";
+
+type DetailBackTarget = {
+  destination: string;
+  href: string;
+  label: string;
+};
+
+const pageOrder = new Map([
+  ["/", 0],
+  ["/cv/", 1],
+  ["/writing/", 2],
+]);
+const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+const copyResetTimers = new WeakMap<HTMLButtonElement, number>();
+let pendingDetailBackTarget: DetailBackTarget | undefined;
+let scrollFrame = 0;
+let transitionObserver: MutationObserver | undefined;
+let printOpenDetails = new Set<HTMLDetailsElement>();
+
+const isDetailPage = (pathname: string) =>
+  /^\/(?:publication|writing)\/[^/]+\/?$/.test(pathname);
+
+const isMainPage = (pathname: string) =>
+  pageOrder.has(pathname) || pathname === "/publications/";
+
+const savedTheme = () => {
+  const value = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith("site-theme="))
+    ?.split("=")[1];
+  return value === "pastel-dark" || value === "pastel-light"
+    ? value
+    : undefined;
+};
+
+const updateThemeLabel = () => {
+  const toggle = document.querySelector("#theme-toggle");
+  const isDark = document.documentElement.dataset.theme === "pastel-dark";
+  toggle?.setAttribute("aria-label", `Switch to ${isDark ? "light" : "dark"} mode`);
+};
+
+const applySystemTheme = () => {
+  if (savedTheme()) return;
+  document.documentElement.dataset.theme = systemTheme.matches
+    ? "pastel-dark"
+    : "pastel-light";
+  updateThemeLabel();
+};
+
+const pageLabel = () => {
+  const label = document.title.replace(/ · Benjamin Steenhoek$/, "");
+  return label === "Benjamin Steenhoek" ? "Home" : label;
+};
+
+const detailBackTarget = (): DetailBackTarget | undefined => {
+  const target = history.state?.siteDetailBackTarget;
+  return target &&
+    typeof target.destination === "string" &&
+    typeof target.href === "string" &&
+    typeof target.label === "string"
+    ? target
+    : undefined;
+};
+
+const saveScrollPosition = () => {
+  history.replaceState(
+    {
+      ...(history.state ?? {}),
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+    },
+    "",
+  );
+};
+
+const restoreScrollPosition = () => {
+  const { scrollX, scrollY } = history.state ?? {};
+  if (!Number.isFinite(scrollX) || !Number.isFinite(scrollY)) return;
+
+  const previousScrollBehavior = document.documentElement.style.scrollBehavior;
+  document.documentElement.style.scrollBehavior = "auto";
+  window.scrollTo(scrollX, scrollY);
+  window.requestAnimationFrame(() => {
+    document.documentElement.style.scrollBehavior = previousScrollBehavior;
+  });
+};
+
+const configureDetailBackButton = () => {
+  const button = document.querySelector("[data-detail-back]");
+  if (!(button instanceof HTMLAnchorElement)) return;
+
+  const fallback = window.location.pathname.startsWith("/publication/")
+    ? { href: "/publications/", label: "Publications" }
+    : { href: "/writing/", label: "Blog" };
+  const target = detailBackTarget();
+  const label = button.querySelector("[data-detail-back-label]");
+  button.hidden = !isDetailPage(window.location.pathname);
+  if (button.hidden) return;
+
+  const destinationMatches = target?.destination === window.location.href;
+  const href = destinationMatches ? target.href : fallback.href;
+  const targetLabel = destinationMatches ? target.label : fallback.label;
+  button.href = href;
+  button.setAttribute("aria-label", `Back to ${targetLabel}`);
+  if (label) label.textContent = `Back to ${targetLabel}`;
+};
+
+const updateScrollTopButton = () => {
+  scrollFrame = 0;
+  const button = document.querySelector("[data-scroll-top]");
+  if (button instanceof HTMLButtonElement) button.hidden = window.scrollY <= 1;
+};
+
+const scheduleScrollTopUpdate = () => {
+  if (!scrollFrame) scrollFrame = window.requestAnimationFrame(updateScrollTopButton);
+};
+
+const writeClipboardText = async (text: string) => {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch (error) {
+      console.warn("Clipboard API unavailable; using selection fallback", error);
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.append(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+  if (!copied) throw new Error("Browser rejected the clipboard copy command");
+};
+
+const configureCodeCopyButtons = () => {
+  document.querySelectorAll(".body pre").forEach((pre) => {
+    if (!(pre instanceof HTMLElement) || pre.closest(".code-sample")) return;
+    if (!pre.querySelector("code")) return;
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "code-sample";
+    pre.before(wrapper);
+    wrapper.append(pre);
+
+    const button = document.createElement("button");
+    button.className = "copy-code-button btn btn-secondary btn-xs";
+    button.type = "button";
+    button.textContent = "Copy";
+    button.setAttribute("aria-label", "Copy code sample");
+    wrapper.append(button);
+  });
+};
+
+const configurePageTransitions = () => {
+  document.querySelectorAll("a[href]").forEach((link) => {
+    if (!(link instanceof HTMLAnchorElement)) return;
+
+    const target = new URL(link.href, window.location.href);
+    if (target.origin !== window.location.origin) return;
+
+    const isHeaderLink = Boolean(link.closest(".site-header"));
+    const isSlideNavigation = link.hasAttribute("data-slide-navigation");
+    const isTransitionPage = pageOrder.has(target.pathname);
+    const isDetailNavigation =
+      isDetailPage(target.pathname) ||
+      (isDetailPage(window.location.pathname) && isMainPage(target.pathname));
+    const isCurrentPage =
+      target.pathname === window.location.pathname &&
+      target.search === window.location.search;
+
+    link.toggleAttribute(
+      "data-astro-reload",
+      !(
+        ((isHeaderLink && isTransitionPage) ||
+          isSlideNavigation ||
+          isDetailNavigation) &&
+        !isCurrentPage
+      ),
+    );
+  });
+};
+
+const configurePage = () => {
+  configurePageTransitions();
+  configureDetailBackButton();
+  configureCodeCopyButtons();
+  updateScrollTopButton();
+  updateThemeLabel();
+};
+
+const finishTransitionScroll = () => {
+  if (document.documentElement.hasAttribute("data-astro-transition")) return;
+  transitionObserver?.disconnect();
+  transitionObserver = undefined;
+  delete document.documentElement.dataset.transitionScroll;
+};
+
+const handleClick = async (event: MouseEvent) => {
+  if (!(event.target instanceof Element)) return;
+
+  const themeToggle = event.target.closest("#theme-toggle");
+  if (themeToggle) {
+    const nextTheme =
+      document.documentElement.dataset.theme === "pastel-dark"
+        ? "pastel-light"
+        : "pastel-dark";
+    document.documentElement.dataset.theme = nextTheme;
+    const secureCookie = window.location.protocol === "https:" ? "; Secure" : "";
+    document.cookie = `site-theme=${nextTheme}; Path=/; Max-Age=31536000; SameSite=Lax${secureCookie}`;
+    updateThemeLabel();
+    return;
+  }
+
+  const backButton = event.target.closest("[data-detail-back]");
+  if (backButton instanceof HTMLAnchorElement) {
+    const target = detailBackTarget();
+    if (target?.destination === window.location.href) {
+      event.preventDefault();
+      history.back();
+    }
+    return;
+  }
+
+  if (event.target.closest("[data-scroll-top]")) {
+    window.scrollTo({
+      top: 0,
+      behavior: reducedMotion.matches ? "auto" : "smooth",
+    });
+    return;
+  }
+
+  const copyButton = event.target.closest(".copy-code-button");
+  if (!(copyButton instanceof HTMLButtonElement)) return;
+  const code = copyButton.closest(".code-sample")?.querySelector("code");
+  if (!code) return;
+
+  const previousTimer = copyResetTimers.get(copyButton);
+  if (previousTimer) window.clearTimeout(previousTimer);
+  try {
+    await writeClipboardText(code.textContent ?? "");
+    copyButton.textContent = "Copied";
+    copyButton.setAttribute("aria-label", "Code sample copied");
+    copyResetTimers.set(
+      copyButton,
+      window.setTimeout(() => {
+        copyButton.textContent = "Copy";
+        copyButton.setAttribute("aria-label", "Copy code sample");
+        copyResetTimers.delete(copyButton);
+      }, 1800),
+    );
+  } catch (error) {
+    console.error("Could not copy code sample", error);
+    copyButton.textContent = "Copy failed";
+    copyButton.setAttribute("aria-label", "Code sample could not be copied");
+  }
+};
+
+systemTheme.addEventListener("change", applySystemTheme);
+document.addEventListener("click", handleClick);
+window.addEventListener("scroll", scheduleScrollTopUpdate, { passive: true });
+window.addEventListener("pagehide", saveScrollPosition);
+window.addEventListener("pageshow", restoreScrollPosition);
+window.addEventListener("beforeprint", () => {
+  printOpenDetails = new Set(
+    [...document.querySelectorAll("details")].filter((detail) => detail.open),
+  );
+  document.querySelectorAll("details").forEach((detail) => {
+    detail.open = true;
+  });
+});
+window.addEventListener("afterprint", () => {
+  document.querySelectorAll("details").forEach((detail) => {
+    if (!printOpenDetails.has(detail)) detail.open = false;
+  });
+  printOpenDetails.clear();
+});
+
+document.addEventListener("astro:page-load", configurePage);
+document.addEventListener("astro:before-preparation", (rawEvent) => {
+  const event = rawEvent as TransitionBeforePreparationEvent;
+  saveScrollPosition();
+
+  const isPageChange =
+    event.from.pathname !== event.to.pathname ||
+    event.from.search !== event.to.search;
+  if (isPageChange) document.documentElement.dataset.transitionScroll = "instant";
+
+  const fromIsDetail = isDetailPage(event.from.pathname);
+  const toIsDetail = isDetailPage(event.to.pathname);
+  if (toIsDetail) {
+    pendingDetailBackTarget = {
+      destination: event.to.href,
+      href: event.from.href,
+      label: pageLabel(),
+    };
+    event.direction = "forward";
+    return;
+  }
+  if (fromIsDetail && isMainPage(event.to.pathname)) {
+    event.direction = "back";
+    return;
+  }
+
+  if (!(event.sourceElement instanceof Element)) return;
+  if (!event.sourceElement.closest(".site-header")) return;
+  const fromIndex = pageOrder.get(event.from.pathname);
+  const toIndex = pageOrder.get(event.to.pathname);
+  if (fromIndex === undefined || toIndex === undefined || fromIndex === toIndex) {
+    return;
+  }
+  event.direction = toIndex < fromIndex ? "back" : "forward";
+});
+document.addEventListener("astro:before-swap", (rawEvent) => {
+  const event = rawEvent as TransitionBeforeSwapEvent;
+  event.newDocument.documentElement.dataset.theme =
+    document.documentElement.dataset.theme;
+  if (document.documentElement.dataset.transitionScroll === "instant") {
+    event.newDocument.documentElement.dataset.transitionScroll = "instant";
+  }
+});
+document.addEventListener("astro:after-swap", () => {
+  if (pendingDetailBackTarget?.destination === window.location.href) {
+    history.replaceState(
+      { ...history.state, siteDetailBackTarget: pendingDetailBackTarget },
+      "",
+    );
+  }
+  pendingDetailBackTarget = undefined;
+  transitionObserver?.disconnect();
+  transitionObserver = new MutationObserver(finishTransitionScroll);
+  transitionObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-astro-transition"],
+  });
+  finishTransitionScroll();
+});
+
+applySystemTheme();
+configurePage();


### PR DESCRIPTION
## Summary
- consolidate theme, navigation, transition, scroll restoration, Back/Up, copy, and CV print orchestration into one cached module with delegated listeners
- retain Astro ClientRouter for directional page/detail transitions and exact history restoration, while preventing listener rebinding across swaps
- replace layout-driven CV disclosure animation with native details plus compositor-only reveal motion; remove redirect JavaScript in favor of existing zero-delay meta redirects
- improve narrow/touch navigation, 44 px controls, landscape header height, wrapping, image behavior, activity scrolling, and table/code containment

## Runtime measurements
Production build, 63 pages:

| Measurement | Before | After |
| --- | ---: | ---: |
| External JS | 16,286 B / 5,532 B gzip | 22,770 B / 7,790 B gzip |
| Repeated controller inline script | 42 × 11,764 B = 494,088 B | 0 B |
| All inline script instances / unique bodies | 107 / 25 | 42 / 1 |
| Aggregate inline JS in built HTML | 517,536 B | 19,698 B (-96.2%) |
| Common cold-page JS, raw | 28,519 B | 23,239 B (-18.5%) |

The new site controller is 6,484 B / 2,258 B gzip and is cacheable across routes. The remaining inline script is the 469 B pre-paint theme bootstrap. ClientRouter remains the largest runtime cost at 16,286 B / 5,532 B gzip; it is retained because directional/detail transitions and exact back-scroll behavior provide concrete UX value.

## Validation
- `npm run build`: all 63 static routes generated successfully
- desktop journeys: homepage sections, writing/publication archives and details, code copy, header Back/Up, browser history, exact 900 px archive restoration, theme toggle and persistence across swaps
- CV: native disclosure open/close, compositor-only reveal, reduced-motion rule, before/after-print disclosure state restoration
- redirects and 404: meta refresh/fallback link without runtime script; production 404 response and home link
- representative mobile profiles: 320×568, 375×812, 412×915 portrait and 667×375 landscape across home, CV, writing, publications, details, and 404
- mobile results: zero document overflow, sticky header preserved, 44 px navigation/theme/Back/Up/disclosure targets, 60 px landscape header, wrapping publication/CV actions, and contained horizontal table/code scrolling

## Residual opportunities
- Removing ClientRouter would save another 16.3 KB raw / 5.5 KB gzip, but would intentionally drop the current transition and SPA history UX.
- The viewport matrix was exercised in production Chromium; a final physical iPhone Safari/Android Chrome smoke pass remains useful for engine- and device-specific behavior.