### PR TITLE
Polish CV section dividers and profile links

### DIFF
--- a/cv/academic-cv.md
+++ b/cv/academic-cv.md
@@ -7,7 +7,7 @@ output: public/files/benjamin-steenhoek-cv.pdf
 
 # Benjamin Steenhoek
 
-[![Website](icons/globe.svg) benjijang.com](https://benjijang.com) · [![Email](icons/email.svg) me@benjijang.com](mailto:me@benjijang.com) · [![GitHub](icons/github.svg) github.com/bstee615](https://github.com/bstee615) · [![LinkedIn](icons/linkedin.svg) linkedin.com/in/ben-steenhoek](https://www.linkedin.com/in/ben-steenhoek)
+[![Website](icons/globe.svg) benjijang.com](https://benjijang.com) · [![Email](icons/email.svg) me@benjijang.com](mailto:me@benjijang.com) · [![Google Scholar](icons/scholar.svg) Scholar](https://scholar.google.com/citations?user=uJk56S4AAAAJ) · [![GitHub](icons/github.svg) github.com/bstee615](https://github.com/bstee615) · [![LinkedIn](icons/linkedin.svg) linkedin.com/in/ben-steenhoek](https://www.linkedin.com/in/ben-steenhoek)
 
 > AI/ML researcher building code-editing and agentic systems for software engineering. Current focus areas are LLM post-training and agent harness engineering. Research interests include agent evaluation, LLM fine-tuning, software security, and program analysis.  
 > Based in Des Moines, Iowa.

--- a/public/files/benjamin-steenhoek-cv.pdf
+++ b/public/files/benjamin-steenhoek-cv.pdf
@@ -4,8 +4,8 @@
 <</Title <FEFF00420065006E006A0061006D0069006E00200053007400650065006E0068006F0065006B00202014002000410063006100640065006D00690063002000430056>
 /Creator (Chromium)
 /Producer (Skia/PDF m151)
-/CreationDate (D:20260823200320+00'00')
-/ModDate (D:20260823200320+00'00')>>
+/CreationDate (D:20260823202032+00'00')
+/ModDate (D:20260823202032+00'00')>>
 endobj
 3 0 obj
 <</ca 1
@@ -46,7 +46,7 @@ endobj
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [105 720.75 170.25 731.25]
+/Rect [81 720.75 146.25 731.25]
 /A <</Type /Action
 /S /URI
 /URI (https://benjijang.com/)>>>>
@@ -56,7 +56,7 @@ endobj
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [105 722.25 112.5 729.75]
+/Rect [81 722.25 88.5 729.75]
 /A <</Type /Action
 /S /URI
 /URI (https://benjijang.com/)>>>>
@@ -66,7 +66,7 @@ endobj
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [178.5 720.75 265.5 731.25]
+/Rect [154.5 720.75 241.5 731.25]
 /A <</Type /Action
 /S /URI
 /URI (mailto:me@benjijang.com)>>>>
@@ -76,7 +76,7 @@ endobj
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [178.5 722.25 186 729.75]
+/Rect [154.5 722.25 162 729.75]
 /A <</Type /Action
 /S /URI
 /URI (mailto:me@benjijang.com)>>>>
@@ -86,42 +86,62 @@ endobj
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [273.75 720.75 367.5 731.25]
+/Rect [249.75 720.75 290.25 731.25]
 /A <</Type /Action
 /S /URI
-/URI (https://github.com/bstee615)>>>>
+/URI (https://scholar.google.com/citations?user=uJk56S4AAAAJ)>>>>
 endobj
 17 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [273.75 722.25 281.25 729.75]
+/Rect [249.75 722.25 257.25 729.75]
 /A <</Type /Action
 /S /URI
-/URI (https://github.com/bstee615)>>>>
+/URI (https://scholar.google.com/citations?user=uJk56S4AAAAJ)>>>>
 endobj
 18 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [375 720.75 507 731.25]
+/Rect [297.75 720.75 391.5 731.25]
 /A <</Type /Action
 /S /URI
-/URI (https://www.linkedin.com/in/ben-steenhoek)>>>>
+/URI (https://github.com/bstee615)>>>>
 endobj
 19 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
 /Border [0 0 0]
-/Rect [375 722.25 382.5 729.75]
+/Rect [297.75 722.25 305.25 729.75]
+/A <</Type /Action
+/S /URI
+/URI (https://github.com/bstee615)>>>>
+endobj
+20 0 obj
+<</Type /Annot
+/Subtype /Link
+/F 4
+/Border [0 0 0]
+/Rect [399.75 720.75 531 731.25]
 /A <</Type /Action
 /S /URI
 /URI (https://www.linkedin.com/in/ben-steenhoek)>>>>
 endobj
-20 0 obj
+21 0 obj
+<</Type /Annot
+/Subtype /Link
+/F 4
+/Border [0 0 0]
+/Rect [399.75 722.25 407.25 729.75]
+/A <</Type /Action
+/S /URI
+/URI (https://www.linkedin.com/in/ben-steenhoek)>>>>
+endobj
+22 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -131,7 +151,7 @@ endobj
 /S /URI
 /URI (https://www.microsoft.com/en-us/research/group/codeai/)>>>>
 endobj
-21 0 obj
+23 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -141,7 +161,7 @@ endobj
 /S /URI
 /URI (https://code.visualstudio.com/docs/editing/ai-powered-suggestions)>>>>
 endobj
-22 0 obj
+24 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -151,7 +171,7 @@ endobj
 /S /URI
 /URI (https://code.visualstudio.com/docs/agents/overview)>>>>
 endobj
-23 0 obj
+25 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -161,7 +181,7 @@ endobj
 /S /URI
 /URI (https://code.visualstudio.com/docs/agents/overview)>>>>
 endobj
-24 0 obj
+26 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -171,7 +191,7 @@ endobj
 /S /URI
 /URI (https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent)>>>>
 endobj
-25 0 obj
+27 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -181,7 +201,7 @@ endobj
 /S /URI
 /URI (https://github.com/features/copilot/cli)>>>>
 endobj
-26 0 obj
+28 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -191,7 +211,7 @@ endobj
 /S /URI
 /URI (https://www.microsoft.com/en-us/research/group/codeai/)>>>>
 endobj
-27 0 obj
+29 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -201,7 +221,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/deepvulguard/)>>>>
 endobj
-28 0 obj
+30 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -211,7 +231,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/deepvulguard/)>>>>
 endobj
-29 0 obj
+31 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -221,7 +241,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/rlsqm/)>>>>
 endobj
-30 0 obj
+32 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -231,7 +251,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/rlsqm/)>>>>
 endobj
-31 0 obj
+33 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -241,7 +261,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/rlsqm/)>>>>
 endobj
-32 0 obj
+34 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -251,7 +271,7 @@ endobj
 /S /URI
 /URI (https://github.com/ISU-PAAL)>>>>
 endobj
-33 0 obj
+35 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -261,7 +281,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2024-04-14-deepdfa/)>>>>
 endobj
-34 0 obj
+36 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -271,7 +291,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2024-04-14-deepdfa/)>>>>
 endobj
-35 0 obj
+37 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -281,7 +301,7 @@ endobj
 /S /URI
 /URI (https://github.com/ISU-PAAL/DeepDFA)>>>>
 endobj
-36 0 obj
+38 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -291,7 +311,7 @@ endobj
 /S /URI
 /URI (https://github.com/ARiSE-Lab/TRACED_ICSE_24/tree/main/tracer)>>>>
 endobj
-37 0 obj
+39 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -301,7 +321,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2024-04-14-traced/)>>>>
 endobj
-38 0 obj
+40 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -311,7 +331,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2024-04-14-traced/)>>>>
 endobj
-39 0 obj
+41 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -321,7 +341,7 @@ endobj
 /S /URI
 /URI (https://github.com/ARiSE-Lab/TRACED_ICSE_24)>>>>
 endobj
-40 0 obj
+42 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -331,7 +351,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/codesense/)>>>>
 endobj
-41 0 obj
+43 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -341,7 +361,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/codesense/)>>>>
 endobj
-42 0 obj
+44 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -351,7 +371,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2023-05-14-empirical/)>>>>
 endobj
-43 0 obj
+45 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -361,7 +381,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2023-05-14-empirical/)>>>>
 endobj
-44 0 obj
+46 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -371,7 +391,7 @@ endobj
 /S /URI
 /URI (https://github.com/ISU-PAAL/DL-VD-Empirical-Study)>>>>
 endobj
-45 0 obj
+47 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -381,7 +401,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/tree-climber)>>>>
 endobj
-46 0 obj
+48 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -391,7 +411,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/pal-tools)>>>>
 endobj
-47 0 obj
+49 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -401,7 +421,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2024-12-19-phddissertation/)>>>>
 endobj
-48 0 obj
+50 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -411,7 +431,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2021-12-19-msthesis/)>>>>
 endobj
-49 0 obj
+51 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -421,7 +441,7 @@ endobj
 /S /URI
 /URI (https://benjijang.com/publication/2021-12-19-msthesis/)>>>>
 endobj
-50 0 obj
+52 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -431,7 +451,7 @@ endobj
 /S /URI
 /URI (https://arxiv.org/abs/2506.00750)>>>>
 endobj
-51 0 obj
+53 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -441,7 +461,7 @@ endobj
 /S /URI
 /URI (https://github.com/codesense-bench/codesense-codes)>>>>
 endobj
-52 0 obj
+54 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -451,7 +471,7 @@ endobj
 /S /URI
 /URI (https://arxiv.org/abs/2510.08996)>>>>
 endobj
-53 0 obj
+55 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -461,7 +481,7 @@ endobj
 /S /URI
 /URI (https://github.com/microsoft/SWE-Bench-Mutated-CAIN26)>>>>
 endobj
-54 0 obj
+56 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -471,7 +491,7 @@ endobj
 /S /URI
 /URI (https://arxiv.org/abs/2412.14306)>>>>
 endobj
-55 0 obj
+57 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -481,70 +501,59 @@ endobj
 /S /URI
 /URI (https://arxiv.org/abs/2412.14308)>>>>
 endobj
-56 0 obj
+58 0 obj
 <</Filter /FlateDecode
-/Length 11276>> stream
-xœÕ}Ùne9’Ø»¾â<0‡±q™ÊÔ<]€? íé†¡`ÚOý÷FpžEWÊÔUªº‘%)î%Á-ö CÊå›ßüö_ù3fÜ~üùðŸä ¥|^@'›þöãÏØôÿÿã_·úË?þöð/ÿJÛßþßƒ~?2m9Æíÿçáßþíá?fS$Dç£§¼°ó‚åkÿë¿lÿñ‹Cò–cªCºÈ€›KL°¹¤MvüíÁoAJ+¨müˆ;€ì É\J6—‰ô¿@±Œt ÖÁoÀÐ›ê¯
-
-b, ç€Q?^[)h×JAK+9¶’c+±­^7e1…eˆóæI6Ç¥ÍøÇß¾þñð/O¼nüûÔÍ[`t’)Ê¶?þ|øoÞcöžÙ{~ªÿ<yâ=ôŸÑÇoOÞy/â='ï%´Ÿà½Äÿ¾ýñ¾ÿq5&ù6&flc’¯cÊãÉx¡Ž‡úyòž¿œátcÌD.#¤´1PsiOuŒú”}Ÿâb)m1ÆNG›ý§8Úy„o
-ë}þ[=ŽÂÁ%
-ÁTÚúcHpA¿©£?Žíüùà|N›C€´9H¾î‡=lZÀ6=Ôy{~Ð“®_PTëŸÑAÚžõ[ú3OP^¿Œ°w>ëßØþŽú“ÆÏ\{Òoÿý’K¸e7@që ê%˜zq˜z·½Yé"n .§úåÚQrÊúü°|ZþD‡Aÿ”Ú/”Ÿu€þ·¸\èˆóïÑÍßË]ún·éí³Ûêb†ä@ŠÙ†‡mvÏí?‰èGúÅ?M£çö;AÌµÉ³ùö9´¶Ó"qžsÚPD`Ô®#ˆc|^€Å
-œÍO£ùßëdß‹Š]€W*brR^©˜@ƒðl~
-ÜSqkË@FÜE”Í+›8 çÖáN7HÚ0–~ºDð~»ø­(]ìæ†hßÉ…±è¿¯Þ¶ËT”NÉyN¼ùíÿ½é­•Cè—Kƒ/­QjŸ…ö™÷°uþ¨\«uÛßØ¸Yð±ržÁåÄ{½«†ß¼çïÞë5¹r ˆ•[-ÿ¾õ#ùÚë¹LPØˆœrZ¿ÎBrÐ†}ª°N	¢Ë’È˜NåˆŽBJ!ŒêÙA=N£EE69Ÿ1G0ðUW¾ž‡Hg‹Ç‹®.o—×±…:803Í®*§Î.¤_AùOLÉ×‹¯Z\þ}½™¢Sž
-Eû-û'>v`ü¹¶~ûz•Kãöçz—+‡r‰#æ½‹ÅØƒ ¡	8ƒŠŽ™óöC' I‚'b¤¼AvècŠ¨BC9Ž¬šå0ùñ`>-–nzßcÄ‰Å‡¹ŽñBF§­ˆ1?À»äƒ  ù0» ‰#›N’‘Ä	–ñ¢c!DH³à8æ,*ìÄ
-žR²´²‹9š9aÉ‡`©&’ø¤Ê‚™grˆ‰‚ÏË’TÖÅSöµýx0ŸM¢g/ƒè9Ü$Z±í˜M¢'“èIêüíÇÃü¼µQEÎôÓûž#N,~<Ô
-¶ 	[‘$<¬$ÏIé­ØÌ_ï¾ìØ9ÕfþÍštŒÇâYÒæ*/+ßvÃ$rî;­s‡ÙMw\§z:<üýá>P;¨ô<ävÙ‚²aÕçö®ŸåòQ¶ŸüÏß/Šx—$ø´aŠ.§„*ºƒCÄˆúl¡™RƒÎÎ¡¦‡»Ê…¢HaGŠD—’¬¤L¨Ezöpý(RfÇ(^R‚OBöqAÄ@Ò¦‡sè‘”÷*Øù˜´¹Ð££ìU5ú,ònÚË»aÚ›÷,Ó ÂßªHZ~rƒ}Ù‹³C¼|)èˆIÇAm	"1ÕÉÈäâÏK,»æoY²N¥leÛç­ìøìDÕ„§W¨G
-)oâ †ÂÝA9”$‰Ir½~“çHq—c ð¤×cpÌ1‚”?¢~¯›0 0†:Îl©ŽÍ0êoí–oø¨ÑBÛÈ6ñ…4.|q¶jnQ³4æW¨á)¦+ªX¥NºÁnŠ ƒŠb”ùñ@[¡o|aNÁègNÑÐNæDmÌú¤@Êÿ+ã-6M1ù2ô'`H)D>«2e®¾Äì2fÕÏÍÅe æ’3=œC?êÏ”¼’)º„yåGhP6íÏ¡FH`½taå¬YØq†•M Ey¶?‡~!à18OEe1”èÝíbYÅ‚Þ¶“ðý™+:`Hy+øà¸¸>+s5[–¦¦å­ø[ø,©6ñ.ÀÞ©ðò³|öÐÁOù\ÈÍ#©›ÖŠP¾=ùƒ*0AÔTî2û	aKÎSRÅŽ!Æ¢FÉ‰IÁ)@)Š£G€6tX(„õ·œŠ:Èœ¢HaUN0¦à•½aVÿº9EVÞ£fT§ó>xRíG5û„#R§‰:Ü\dJ^÷QÊÄ3nÙyð·Ò_½#†¨*¦cµ°çÔã½Âæ8ˆ>¨Îí)jóH,YŠš¼PÖ¡]Îä!=TQðt^Ô­ÇLªòç$:ˆ1+£…ä€‡Tô÷” ¨½$;òªAnäbÏDU»”T™N³ oBŠ¨z£¸”}
- ›F]Uä}H‚©nJ¢‹7$§RDr¹x¢ƒŠc¶ì€]’õoáòÕÚÔ;ª-Õ¥“Q¡=_}9â«3FåÚþ©¶‘â»¡"¨¨ºž¥öÑ¡~C­›œžP_öƒ§ÖQ(ê»:rþù çwC”7q	*¥«Ë	¶>—ýçÒkrR…´Ô©ïBTreer%ÏëV¦-»Ò‡.tt¬{ªÏ¡ºÌ¨ÍÚë‚à’ÚBhß—Š]š,œ^FJ‘ZcØÏ›8€:lvPÈT#L§GW¶R®»!R%!9ú|ÕoÝ+­Çê÷d¨­Ð0Häæ1S²¡-{pÅZPpžCQ…Ç,’4H Ðå@D´ Ù¥tÒAt>aªð]÷ÜDçŸê–H£!WO–´å£2uî«Ü¦P×Õsm€v]X\*ÔMW½˜DS±MæSµ	À¶!€«óË>âºÛt¸}79È`®.ÑÖA#öžwàØºƒžtéH‡òMR ï'Y/&ðQe]ðËIõ!¸L±ÜÙZ]Ày½©°j>À©ØMEãôs(Œ);½‰¤Ü±ÎUr^bmŠŽRPÛ‡ÎZN>¥zß¦‚©Hö{/˜«É€
-@Ò[›|1ÿz°~“"dŒºf!fbõÎ)ñ’ËEÏ)«-´ž)Q†Â’D,ƒ‹$åzíJP¼Sˆª/IJmÑr5U? Å”OèÎ¥„¬Ó£»Îû Ð¶ ùbñqR"ª¾÷‹ùX§šsñDƒÇYYˆ€ë6—#g`â)Ñæ"b	°ýÇ›\Ù÷“ÑSqø¯ú@—‘òj9²`+
-›N.À÷—‰²^rj§bÚùÌÒ±Av±<}1Ñ¯-äF.œ§R¢å»-ìE¯*`uˆþª¤ÌB-Àæ¶¬,Á‡¶kþv9YÍ?eR¶ùÛŸ:W™ÐgíŒv`r"“o„
-„z™C½ÂçÉZý ©ŠöÛ*15†Dskh ìbª,UnqnìÍã4¹gX‹áE0x'Eð«n— ñæN-æ§¸HšD©¬R*{NõKEŒêìyOŽ•NèÄ^Å…6Ûôéí×5åRt¶ÒÅà+uÑ±ïñHì"ªLÝA"ÀÆ=fuE‡!fUœgQ¹ERÈTíx„R{Ô&—9q±Éù€ ž¨Ìœ!¢‚eª6À
-dY¼š{gì½€Ä1¬v›È‡\DÌŽ 9Fô9ª{¬’Az¯&5›vrÉa¬òcÑ6r’ªAPÙSQZ„„9„-¸röY`&ò”¹ÈÅ^ï-/E½ó4
-Ô!+*'˜$v˜¤…âùMq)¥œ¶ÙcPõ†B¢1ö¦ºhÈ¡ˆÉ˜·è@X„ŠžPi‰z©"®~\cå¡jå«;Øž~RõÁn’°G":ß8ñ9Ô6>ãýCÑÞWÄÝi z¬8kº¸Õg“…í<5¶5ž¦°“8a§ì§†«!GgjÏ–J¿=ˆ(Ù )áæ0«ì„kððxÉ¦ü–:!%Ðç±"Tbvžj”’w)¥äObgkXÓwê‘FÝTñc›)33=¶Ï7ªÁïfñ¬M7sE¯úÅÆò¶1CÃ9Ô];»Òf»´Ïm…Ä|<z/_=F6Mœ~iÒoqÖ] m0´ˆ,1óØðµxp˜‘[ƒ^1ó}/ý?ÕE¯T:¨ÑÕè.;,¶6lp|óü.1Æ'{+÷ð®²%š}Š
-:áç§‘nlÁÒï£Ù
-iÝ¶e
-Âú½Òö©m×¸…þr²Tú·	9—tˆçŸÎ—F—ÚÒ;–&,ÉÓë·å˜³Õú1’Ô&Dêvó3´«°_wiç½G$ö}#~÷ý>	íŒqû	pkŸÀˆkG™{»Ÿ»@eã\Ä²|ÃíqÝ\cÒûB´‰šøhì±
-ójp¸Ýž{àŒg,šjå;
-8t
-Zäœ×ÐvÉ3ðëå'tõÉ½ÕˆIµ
-$Æ`Û´Ö8ûLìÞÁegáò“©#½-(ô¸ü#}ƒL*Æ8?òºó^Ï÷§‰g4@Z}ñ>;µÐ°ÊUYœ„”Ä@Ÿ-‚C¨PÓÃ9Ôôp'›€ß4í|*	(ŸÈ p¶‹R´	9ñ÷‹kkFŒëM/OCAÏjA,¸±åyœ®_	V1Ó™âÁ8ðsò[O£*É’'-|B#P4ÃD°Ø³9£þ¦0AOêðH£$*°ÔóR¬ò0¨dOê…¢hè!;¥×0Æ¤Ø5ÂL/mõÃ¤ µ‘*@ÚIæP`Ú·ªT:šÞd
-S,¨èzŠ¥ÚZñUE«àßÐ©µþÎE­ŒÄ15z`
-Ç‚Æ‚>TOä@—ÑPsh‚çhðB#b0øc‹2!K(:ÊIÝEfFÐ¡P¤Fh9t ˆ¬æh3Å¨FïÈ!šÅ —‡žÕË‚ª³p~…híyö…hZF%ºF¼¼-jÕøûBôB§/¿¶™_•ðÞ1s¾tËû‚–š«á+Â›]5_ÖÒW=¬³ßìNèíìž™#ØÝÕq±»°ãl·ë¤Înì6fû÷É²ç¤Lkhþ§q¢úØ“×*´Eüû¥
-úéÒÆÓ*'Ý”ëŸ~Np=È„bRZžÚ÷Ó¼ZûU;t;+t7-¸ŒÓÂŠüÔ¯áOÃÄUð°ÅPœG\l£zèÀK´àçY#xvr6Ü7ž‡9:Í#]èaÍ}I)å•¶ˆ›N.ÀGOHê'O¼£‡Õ¼ËaGÎ€.hÏ..ÀGjÞ=:)£úä4°TÚ1»OœdðW‘ñ½ ñ½XIKhšÊßÑ¨h°3¤5‰ŒÂL:x8Kvû)}äÄÆ‡KPó¤Í?Ùké\å˜\Ü™íÊÕë¿ÅöŽæ–âwRQïûj+&*¿³	Ä™nÞÕléó´7•kûeÜ•§`WÂ¬1doo:³qOsLÍVw<éÕhì…»II/ÛP4y»lÈAÇÔó5HVQ—¤ˆVÒ%)rXNRä^$]
-GI—B#ØŠôwH«¨K¡´²’.…Ò7Z©…BÁWI—BÁ×
-º
-*.ý=®‚îøÌˆV½#ƒ™±Œ´6°2R]GÞˆ†J#'Žù0òä˜7#yš	62êX
-#ËöÃ²˜‹˜K|s‰b.q¡y•r‰Šà¬”K¤$kø„¡³Ë*æj†kÖ¨A;qts‰ÎÄ\¢£˜KTV’V1W¡fÐQÌm#À*æV\B¶bîÀÙîÕIÝÕ}ÌæïÓeO	õÁž'>Ê¹c¥B[Å—å\J¹D£Êg£®ÇiüY.Í½1´Ý]Ã¸L›häád˜“	·]Œ¾'²po·Ü•éDæiÇ<3N[;ê»ž/ìø/Ùk»Íw¤«ÇÕ7Rì¾¯`ˆ4±ÜÉcÇZðŽÙ~Ò9Æ¼ö5Ës»ioŸúEc…Žt›ù	w[ùKý÷{=˜UßxO†Ënƒ}m¨[*¿›Åûº³Ð_J3¢«eT&îÃÁôh6Š]T˜†ð³ÃÓ'²´1xúÞ²éç¢‰1êwU:íÑx(úÜ9â~R²Œß[­fÏH{7¿¾ËËŽë¦ä¶sžÉ3égw:‹Çc©–óz™;jØiˆ9J	öµ8Ê‹>iÛ¨ïÊ£âÀgP£Ió-Dc\rÈ-¼íÏLË^ôÙB£¨öY ¦‡s¨éá^é™aÃ[Àvî>­rVõqlÜõL@	*1g/½»¿¦NÅÔï©ÓÊ<~ûîd•UI%7»;5Ú†%.{Ë@Í>4=œC»óNyÐ¢•UD«ØREâ° b iÓÃ9ôþ-IÏ|Öó¦¹Z-ÉøÓž8‹ñþà]š<Âj9­ÒL9Q3I0e¸ûáœyÓûÓ¹?ÍiMœDÄõ´&Ñ¡R’ÂlP5›Ùôp½ÿGÔJQº½[Ôî§ÝÚÓ·lëåòø>;“wëþÜ…“œx‚MiÆWÄá©öiöûô÷ƒ×$ Ê,K ?/àÌRÛN.À¦“»oÿ%‚	È§¿\0ÁÄùwÒba%M½\-¬
-Ð6¶#…©	­…•‹KŒ…UaûX…-¬
-ÕVhL¬
-Û›X–8¶Àñn[S¨"lm¬Öl¬šram¬ó³i×›}L mÚ
-'^Ó¦8ñŸÖGKé´SÎ9™öÌ9wÓði'yšHçrLSêX5,j­¬z*•è¸Ù.°Ë`X¬«™•4ã.e­NbÐ‡ƒ™UaG3«B÷Ñ
-«¦M;ÉpbfU¨b,›]6(‹	‹™µ@ÍVèíì¦“h‚‰‹Ý†pˆ&°ÔÙ­{3ëœ.{TæÄÚCÕ—Àž½¾T¡-ã‹fVÂ°çîMî³Vš%³™éö…%‡»'N¡¶[Î¬Cúg¹pÔ²3µSHºôš±^–-@–¦ËõZÓuðkûNn>™[PL,Â£±OZg[¿M£ãÄüåó.N¾[‹ÍDí’Õn:•‡”:ÐsÁŠ¬›ól\F>q6â‰}ùÛ÷†Œ3ñÀÛg'5§Ïì¬Ä]2[ý¶N¦eG%#OwŠî’n?Ífvìkoì.u’¬-wïi6Ò}àÊ`é7ì±¡Ô…šÂ÷O¥6YoM»Ë¥JÕ¢¢¹Â 'üykp’ÇÝ\€m/÷ýÐøMˆ;’ZD\ I¾ànú¹‚Ÿõî*aôŽëéfÚRpŸªöøÃ†7ø¢aã9‰Ø;°§.|¢s¢~æ •®÷»
-£V8Ia¿«&|Ý=³Ÿ+øì*­B¡ÎÝU?»íÚâ‹;ƒTBÂdøNÿùs		Ç  æJ	ƒƒòŽ¯m~ÒÊñ/lÜ€ÉÈ<eÿ¸Æ¨„Uƒ’pÐ $5(	'”Ä£%ñ¨AI<Ó $5(‰‡pl…ƒTzÐ Ö5(I«5>3"ûèÃ÷f4£¼Œº0ð7Š…¡Ô¨ cNŒª2æÎ(5f’ú3–Ã¨I}Õ°,è¢A‰5(‘£%rŽMÂGJ¸h²Êg”ðQƒ.½¯“ÌgT¹v”pYL^5(…š­ÀGÊŒ`·WÇÅnC>jP†:»µû<˜ÀGÊL¬=TrÔ ÆR…¶ŒCƒ:•k%wØ|çKPBÞ)(»H¾žõgã–À’ExK9Ù¦ø5¼_Lƒ-ßêÏøþ%M—ø#1.Ä—åcŠä¸ˆ4s®¬H0æª
-~ÝÍ'@cÅMA:O«ÅwßÏE’›™f÷&?ù:çÝÂ»²525ÃmE)ŽÒ§U“[¶ÑD_MTMžò•¾¿@±%þ±ó‰Í‹¾¾‰ÔB%JõŽ$™Ò!VbÈsßÖ´ØeÃ™, «Aî£‡™¶}£N2	†¦Ë3øälãŽ§ö_”¹A5ŒäB‰¸˜óÿÙô¸¤—b‰Ç¬ÑùJ!õDz«jA¾	~¶`ÒÚœÔÁ£“°íä^Ïº/•¤h#ÜÑ…Ï$š5‹°ìLo½žðÆõ4Â úµè§qL’ÃÒ.vcœ;4Á[»
-ØQOo#Á~ÿ4{IóÜÒºÇQkcyumÙÝ9¡v+›..À°ÃCN%‚«îprŸ¼â¬Ew&>|ž]Á^«ÿ°>ÂÑ!„DFÞ…Ìb¡ÏTÈq¨PÓÃ9töpWÓuj“ÖC7¤>E^ë´D,t"m{8‡H¹C<œ¾•û+ŒŸucLÁD’¨â)»åJÝËâHk„ ¦6­õÛ‘óÈÛ‘µH„ºJ¬ËÂK¬× ¬zôÛoÈÑE¯Õ—ƒ––Œ¹>m§…ÖrB~^À„6\€M'÷½"¸„I«cZzHôežòè‚EÅ‚â¶“ð‘ž÷õ`Ò—oÉ-Ì¿ýj8;2ØÕQ².©C›z\Ôh\n$SøYô1h;}ãàÙRaQÊ9,dLý¤o‰
-ÙÕÄ‰–qg£T¸5Wä©Õ2æeê[‚¦Å ˜e²ü¼˜~5æ„™‹)3ï-¦
-Ú[Lv°˜2ËÁbª°½ÅTaG‹©B÷S…ícNvŒ9QèÞbZ`ÍbÊ%gmšÞægÓD7û˜Æ¼6ÚÎb:ñšæÁ‰ÿ4$ZJ§ÉqÎÉ4MÎ¹›FÌ6É˜‹é\Ži«†eA­Å”™S…í-¦
-;Æœ0ãÁbª°}Ì‰ÂŽS…î-¦
-ÛÇœ(!/S…*Æ¸ÙeÃ²˜¸XLÔl…ÞÎnš:BX,¦»ñ`1µÔÙ­û˜“9]ö¨ÐIÌÉ\{öhXLë2¾sÂ<žþdSÃ©§è-Ó—¥žô9e³O9¹ÊÀOcÒ°¸~ŸU¼K|Ýpô¥~N¹UÂJúüC„<MdÖÆwçÀ’Íj'N§â´z4q±þÞÍÅvûxÃ,È…X g[¯ÈÚ‡m¶z§óª¨à —M:×q›ña·3Þxì³0j2vã—l°#èæeºu›†.P[[«-ã7ÊâŒ6z³
--•îÀÚ3ûd˜M"ÁÇïþåã”\MŸ˜´¨U«çè’×½%œëÄÖ|H´‰}8|¯D±IYœcnlBuüÐBGüî6èËƒdæ¾Î  ƒÙFTYÌS»6¾ŸÍB}ãÁWÝ›´nÂ8Òg¿¬åU‡!þÅ‰=)qšv†{0—>Ñ;bt>JÒÙ@h>D}g…cI•àç[näóÚÉxvr/£IÄ~cÞJøOd;9Z½-ÆéÂ†RÂ7+{T) >17…þ¾¹½û­ÄïƒQ®òOf›ôÖ€wÊ’Â”‹Å=Y
-o}{Š/æ Ï•„:õ´[¾¶Mÿ<6ñ×èÔÍÖøü§ûIË|Ê}_8¯©œKz©‘2DÎ\ƒÕmÝ	…ucJ±¹Æ¿ƒÕãr‰“—lÅâ\#êeÕãr‰½Éêq¹ÄèC¶"y>ËPhÖÊöVË3w€óš;0?3ŠÃèÃ¨ù,w`âe”–¿Qo¥Fsb¦1wFµ2“l”°±FYË†eIE.“¦Tó2Ž’y/8ÔhQØA‘Ë5¼>­Š\®øb¹‡Ð…C_º}áe5×ä5{á˜<`G°û¡/g»c'uvo’ætÙ³‚'¡/}	E.ÏäºŒ/+ry$ìê¼Ë’,ði„‰“K¤•>!Äà¸Ô¶ÿ³¦8cÉ8žàç¬Y	š”ð¼ôq5]ÜÕfEíº¢oFYj"Ÿô8‹ŠO¼mçÐ#5ï-}Vÿç‚…>=«/-~±è°ñ'º6uFŸNÐŸ%ÉàÅ^záY¥µÓùï$à oMzÎ#fŸ…©Û’ûKñ–·H¤åÉK”…n…R±qÿ,ÇQHµ:«¬Ø›„ˆŸÈy…\öq½p4ÐœR¬_ÎÝŸ§téæ|ÿÓ«Žg¨’£¾ÅøùÃÌ¾á7i¬	¡¹HõË¡û­‚©pwªóÿ:­Â¶	wÔ*Xã•JÚÍç^ZÅRÞØF¸ž•{ÅÅ<ìÂË76û4·%”ôÆ»+‹ÅípðÔËÌ{¯—â—
-£&fÖ:ÿzââLR\‰êe±®ìÕ‡bž2íÐþ*ŒT¦…jôéNûdûúeoÅKª9´à%·c™%é›ªÑN÷(½ö¢ì=öç¹³1…‡Õ(·¢0ïû,¡Íl¿w{CâðŒØ˜ø>,[KbÕG_9ÝÈº`Ù¶Q42”µ™Ûç@*Ò9@)Ì0¶1¹¼yË˜´´Š÷~1ìËÉ½Ÿß)²'åñ†X<Dö„Mx}•A÷Nmí!
-S==Xcˆ0Œ!
-S5Óúvtj+toQ˜¬Z«05O„Å¢P5dc)°òÚ³þ¾¾Ê0?›Êwëcqj·ÑvNí†×âÔžøO¥tæœL£Ãœ»iž°“<s9¦Ác¬–µ¶áZìŸ7ÛœÚ
-;:µ…ëC›Å¾¼FPA“NâÓV(åT¾9gÎL!
-;šBº÷iû²–ë«jv‚?ø´ívwùƒ)dâl÷«?ñiÏy0 Í–=(pâÒž`O^_¨ÐñEKˆð>*|Ir7åö¥ÿÕKE6_é‡@Ž«³l"5œ‰ïà¿»—ûÄyúÚ2gÞåQ£"Þv¸	¥&Ï¹o¯™ê®V¢Ú¿Q7æ9íÞæUª±¥¬Ô3DEl¿Ïn³úÐeõ]42`N„èÃî3.ø1ÙûZ¼W5‘ýêý}Ñ¾Ë¿‡Oç|ÅÍÄDú\StB‰2­oíƒ¾¼;ÀÏ+8Q	)`ÓÉxvrßº	Dà‘f¬[z’æId^é±`ƒ¸íäüQôpÈZû_ßf¶ô°d'®ôX°AÜvrþ(z…ò†p^é	]‚¤öQKÄm'à¢G£ýÍÅ0ä ‡à(¤XÛÎ¡Rîñ@K5iåŠ©å	~×I}ƒ±7¡v#†)ÅÿÑp‰°²¥|VÎ‰w5æºÌóÚ7z‰ÍïŠ€·ð;ÍD,‡è»·È!xSúXì–e]ø×Å,Ø6ûªª7­‹ïôŠJq˜&PÁoúêÙ+#¼í.FÄŽÆf±!æûD&H†UWWm`«Œ«[v¯Œ«Sva.‹¢“¬2®nÙ½2®NÙ£2ž±´«Œ««va.åi¦ƒ2žñ¨Œ+¬+ãÅÑkÔºñ™QÿFFQ4£•ràeTÏ¿QR¥Fsb´Þ1wF?6“l4é±FãË†eIm<û£6žýQÏþLOù™ °Bµ¥4å3u<å£:®ÁFº”v–Sàf=R>ªãPþ»¨ã
-{a´3»ÆŒ`ö×ÀÅìÃ³Ù±†:³·Ç<Ì#0¦Ëž¦%°§ÏO}¼,ãËúxæ½]ñÉ¼÷ “¿õë³ê|k?’Ö`ç‘Eóºl™^q½8ô qWp¡|˜J8Ö.Ñ›Ú€–ƒ !êL­Ã°cÄi:’GšŸLx¨ðsD8Ä$x¨"Ñ±ÔŸæèvŠñuõ®EPsíÇëä4úÒ‹tì*v–ÀVø¥²aW³­õ]vìao*1¹ôO«mÄà{
-V ºoJüE§/=ÍÓ“üq'0]½a¿]o ÷§Õø-P8âeKûl4ˆ¾¯dKÁhÞ<¡#ïÙ ÕFãù4¶†¬%>)øò~±/ïl>äÕÁú¼BC©L¡PÛÃ9tôp/]IÝcE;ÒÃ²Û0¿]W:­1ßž›•æ)´Ö¸yêÞ+æVœ”¢sì)*Zšî}ØŽ•À=°÷®ÉÊ.H}ÛzMsÕG3L­ÖÕ—,æ•‰V&ô‰•—æ­œ®>Ápù	÷q$D“/5Êéb@“ Z3‘D5×¬rÉh‚µ	:½%TŸÀO-ÄI&°Jœ3Xy¾ª‰CqÛ9Ë—<œ®£^¾4wƒGÌC2‘xÿÝ×#Çf‰“ùØBÏ{®88ð·OuŸ‚Gqõ@Tßr(Uo}p¬ñºú¼B“Ë±AmàÑÇ}-ƒZú‡9é3ó–P´ÐóŽœ<_:¹ =¨E	RÐ¼aKJQõOKÏžˆ/\€?ˆ­9X/Á…bô*jž¥gOÄ—N.ÀDø¬Ï>©vkéáìêâëÖ_Áñ¥“ðÑ“²êË¾ÒÒi‰\ â•XÛÎ¡{RÞ]º‚úØm!¦Á·šðŸEº:±DŒ;_+®Ìj1Ô]¼¸¸ø+¯ÂÜöíN,Ô·JDÞtDï,Ô÷sŠÿj5¨í’)^£3—Ð€øíé]Â\ÏäªlßÒ¡ðñ2Õ@à¾eOzÁÍVþ$»„j5ÛKÄÑC´)’ÅŒæCeM°%ëC[z5½qV2qÖŽðÉÄ´”´&z‚ò»¸^ûN¡”0SËì€>/Ð€Î‡
-5=œCgwå1YŸ+LT÷6¤äàD8­ˆXèDÚöpý(R"8¨{CJÖÔ—\Ââ"j6=œC?ˆ 	ÄÃJ òŠÊžx/\€?Š=¡1¬'4œy]œl·\€?ŠžÀÉAa$=’“”µ,‘¥Ç‚â¶“ðGÑ“¼fÍ®äÄÄŽ"­gØBÖ¦‡sè‘‚å%¢¼‚^ËMEÕ~":‘¶=œC¤¼{Ùµ•ÎÈSjy7ŸWdžøîë9öR-ã­$¼ˆ>|¡˜ÝÞ“ð¢ æw÷oÅ¿¥Ñò®ÒO
-ã¿.pô#,‘ßx”z9gÁ6CëÓù0ñ}H²7Å÷7—Ó»ß£Œð!ù-âûŠ@ÙH2³ilÙšñÆåÏU,ìÈœ¨°ZdÌb2žVø2v#—'ÍlÙ‘«“öñ0W‰‰ìê3¡s¬Cß*NÒ7ê_›^q©_üú6¸/Û4ï¶iÙºïïêˆ©NáÒÕqíyºtN\·¹t‚¼àêø	7L¯BztÐUg/xnäò“ë)¸òÏ|7ÐÙLOs„ÍÄ°¹ œË; /ïBnAŸÉBjÜSÿÞ+7ÌtN&ž~¼¨ÖŠ$–»à»‰BasåvöýØæ·ë³+c™ØÎáy7uç0³ôïß¨3ç¡&ENPÌÿmx‘%¶<[ÿî×vÍ'û,ÁÅ…	ÙánÜÁŸ¾âÛÌ®(ãîJ*Œ6_frnÕ‰	»Ã	Ö¬<ì|d»­GO²kÕhù¾.#uÉ¬.WBÇ	ñÐáÞöI_jÅ-p»PNf“4¹ª'¨ŽGÌlääã~_ålŠw¹DS˜E¾™³ÙÍMJÁtÿCÞ‹¼ÆOÕ÷–­Ö&Ûžþ~>‡øB¢Ð™ÈyöÊ÷ Øˆ¾ûh!KËˆ8Ú?It#¹‡bp©Ã˜stsÉ¨ç*Ï6»D×ø]ö	®×¯ãk•Ù×ºm~»!DßìäŒ¸œØ…ò°ˆ¾üé‰ôy…fï2T¨éá:z¸ãÃ8íJC¿®Ø¿][=)$1ð[K}”d}Çx.{»€½ÿ†ª›ÀªÉÝÎ 7Mæy:w/aƒ•ï…Ñ9Sl L%¬|±\¦_^'€/•ÄÊ5ú¡ Ô3*%Gæ¸ç\´jRÙ%™ññB“c‚SóÕdéŽ»üØ-…ý
-ÒûDšPY#¶°Ê3vh|> b²'ßÔþý··p×"±¦ëè 1|pXë¯./ìÍV¦0øiFÐN>X^+)¼÷Ò†Œq65‹íK]/åcÛÈ§[©¹€%îRôôæ +ªa>AðzZõ¨FåÎÎ>)9ñÑ§£Ö²Ä¤¯/ke½ôN›ÐgM^Uß
-=œCMw{)¸¾Ôòàà_¾3‡œÜáü<GŸ[ÍfêWñpÛä!r‡Á ü?²Ød:ÿÖ
-Ô3ñæ¸~¯'?ëFusë09Øâ¼*OÃ<aé1JÚè‡§¸ï³Ë,Ã€òÍ|?Õ¿ƒ!¨G1ñ^Ð*z¸°ªQ ÃHl2k£vŒ”›Zù½åst³íãC,Ý‹ÁÇf…tVûÍ¤· )-Ò_ÑàÌ¾+D42ž?nìƒ´¥4¤ý/ÝøÖØËOY"ÒD#½²?±À`¦ã¤‚æÞ…5DZZ„#Í>Ü'/ÈF”ÖÈh{ÈÎr¦¯ÞP8³v\½5`Çä3'˜}+x8ÞZjVr9'¿æ”©$Ý‹Óã£Ìcà*aD,Og×Ã}’°ÛFÉ»ë §f<Î·WÜa[…útÒNeÂìeg)i©vSÐºáÅ	ãÏ®>™˜EIói1ó†YHýÕì¤¢·Ðçšk?ÏkçÐÑÃ½ÞWnÛìÃ_@Ì²øÊm1ë„ŒCÔï.|ÌÎ?Vø˜ã¦iR)ûéï,¸ûÍÔR^’Õw.¨à’&±K¸ÔóK˜D	&K•ÓÌóò”pmN¬š€k`Š½š‡ÑÅ#HÑâÑGßgàF9øqç	2É¶ïÂŠÅ7¡{®É_åUìWð±/¾}á-èÂX¼ÊtÞx»~‰]èl·yJ#¹@>…Uµ¯Ô†eÃo5V ŽTÖ”ýkMc?œsÒ.ÛÍ •ßúÜî«90å^‚e"óÉX0°fÀx‚¸‘ä
-¶Ã™³Ë1ðóœ]ñÂ=ï:¹ NîUý;G§«Üqõ7ù¯âþÿ.nf¼
+/Length 11318>> stream
+xœí}Ùne9’Ø»¾â<0‡±qŒ2•©yOþ€´§å Ó~ê¿7‚kð,º’RRª w#KRÜK2‚[ìA‡”Ëÿ6¿ùí¿;ógÌ¸ýøy÷_wä ¥|^@'›þöãçlúÿÿù/[ýåï»û§¡íoÿ÷N¿™¶ãö÷ÿs÷ïwÿz÷_w³)¢óÑÓF^ØyÁòµÿõß¶ÿüÅ!yË1Õ!]dÀÍ%&Ø\Ò&;Èßÿvç· ¥Ô6~Ä@v€Àd.¥@›ËDú_ XF: ë`‰7`èMõW	…
+1PˆsÀ¨¯­´k¥ ¥•[É±•ØVÏ›²˜Â2ÄysŒ$›ãÒfüýow_ÿ¸û§Þ ·?þýêfƒ-0:ÉeƒÛ?ïþ‡÷˜½göžê?OÞƒxýgôñÛƒ÷DÞ‹xÏÉ{	í'x/ñŸ·?þãîûWc’ocbÆ6&ù:¦ÜŸŒêx¨Ÿ'ïùËN7ÆLä2BJµ1—öTÇx¢OÙ÷É .æÒcìt´yÐŠ£Gø¦°Þç¿Öã(\Ò©Lå ­?æô›:úøãØþÇÏ;çsÚ¤ÍAòu?ìaóÐn´é¡ÎÛãžtý‚¢ZÿŒÒö¨ßBÐŸy‚òúe„¼óYÿÆöwÔŸ4~æÚ“~ûÏ;H.á–ulÜ ]Ä1¬ƒ¨—`êÄaêÝöf¥‹¸¸œê—kGÉE(7èãÝòiùýSj¿P~VxÔúßâr¡#Î¿G7–»ôÍnÓÛg·-ÔÅ6É³Ûì&žÛÞ!;Ñô‹?M£Çö;AÌµÉ£ùö9´¶Ó"qžsÚPD`Ô®#ˆc|\€Å
+œÍO£ùŸu²ß‹Š]€W*brR^©˜@ƒðl~
+ÜSqkË@FÜE”Í+›8 çÖáN7HÚ0–~ºDðv»ø¥(]ìæ†hßÉ…±è¿¯Þ¶ËT”NÉyN¼ùíÿ½é­•Cè—Kƒ/­QjŸ…ö™÷°u~¯\«uÛßØ¸Yð±ržÁåÄ{½«†ß¼çïÞë5¹r ˆ•[-ÿ¾õ#ùÜë¹LPØˆœrZ¿ÎBrÐ†}ª°N	¢Ë’È˜NåˆŽBJ!ŒêÙA=N£EE69Ÿ1G0ðUW¾ž‡Hg‹û‹®.o—×±…:803Í®*§Î.¤ŸAù+¦äëÅ‚W-.ÿ¾ÞÎDÑ)ÏN…"‡ý¿–ý“GŸ» 0þ\[¿ˆýG=‡Ê¥qûy‡ÞåÊá€dâˆyCïb„@qvÄ H¨@Î â‡cfà¼ýÐ	H’ ÃÁ	‡)oú˜"ªÐPŽ#+ƒ¦@9Ì_~Ü™Og‹¥›Þ÷qbñãnE®c¼Ñi+bÌ;ð.ù (h>Ì.HâÈ¦“äD$q‚e¼èX’Á,8Ž9‹
+;ƒq‚§”,­ìbF@ŽfNØCò!XªÉ…$>©²`æ™b¢àó²$•„uñ”}m?îÌg“èÙË z7‰Vl;f“èIÁ$z’:ûq7?omT‘3ýô¾çˆ‹wµ‚-ÀBÂV$Éw+ÉsRz+6ó×»/;vNµ™³&ã±x–´¹ÊËÊ·Ý0‰œûÆNëÜavÓ×©žÎwÞýÛµƒZ@Cn—-(VQ}nïúY.eûÉ¿ý~‘9»˜Šˆ”¢Ë)¡ŠîÌÞ'1ÀGÌì:p´?‡šÞU*ät_ñŽ	.ÀJÈ Z”gûsèG¢Ê#é±XÏû%1Pƒ´éáz$å­Ê.+Úbt”½jEŸEÔM{Q×à‹CoóžešRø[FËOn°/{Av–Ï3É…È˜jd`rñõ’Ê®ù‹D•¬ó([Ùòy+»=;D5ÝéÕé‘BÊ›8È‚¡puFPÎ$Ib’\¯Ýä9RÜÄå<éµ¨.FòGÔïuÓ†PÇ™!Õñ¢Rý­Ýî5VhÙ&¾ÆE¯¢ÍöCÍ,j®àÆü
+5<ÅtE•¢ Ë ÔI7ØMÖ?¨(Æ˜w´úÆæŒ~æÍídNÔÆ¬O
+¤ü¿2.Þb³Í3‘/CFCpž8ÃríE&—D8.—–šÎôpý¨<qp”Å…”DÁEáÌ"j6=œC?Œ”@Î‹Ïa%EÈ1DÙ‘2¡éÙÃ9ô£HÉÈ.KÄ´’=¹èWo iÓÃ9ôýùªRXíÜz1ùà°r­OËXÂ–£©ÅG+þ&‹Iï„g±YðìŠ.¯e´‡þ¿Sà/çxéQ \ô¤òmÌm¯µ3z¾%M»%éi“ë/œ_DÞôŒ3€¿zö¼ê¸›;þ§šŒE(ßž|ŒAµw‚ º%\fŸ!!lÉyJê ÛÀ1 ÄXl!QrRêA]Ó€R¬&BØÐI`¡6Ößr*¶æEŠ¼æc
+^e,"ÌêüE"§È*€©Õ¾ï¼eQƒ	ÔŒsŽH=†êmv‘)yÝB)Î¸eçÁCÜJEiòŽD¢ÚW«{)Ç ';z…Íq}Pƒ“g¤¨Í#±d)6˜ä…²ír&¹aAçE}ÚÌ¤ö®dC1f•6!9 Ä!ãUJÔX˜y5ŸläbÏDÕ´"!¨%)aÌ‚¼!8)¢MÄ¥ìS Ùôê2¨Ë‡„àAa!ˆfHt‘ã†äT”N.—0Œ €rÁ–pƒ¡K²þ-\¾£&«õŽjK½º2*´ çë%¹^:*ìÓö5–;ŠŠ´®¶ª,µ/ˆõjÚoà”Où²<µŽB±]é…õ;q8¿Ê ¼‰KP)…X¯VØþq\jôCvœK¯ÉIÕTR§¾kÉ••É•<_L»™¶ìJºÐÑ±î©>‡Ê¨ÍÃë‚à’ÙBhß—ŠS†,œ^=J‘š"Ø# ›2ÕÙé)æ‡B¹î†H•„ä|èóAT¿t¯´s¨ß“A¢¶>BÃ ‘gP²¡-{p%
+  à<‡¢jPY$i„ Ëˆh²Ké¤ƒè|ÃT´î¹‰Î?”K
+$‡Ñ«'KÚòÎ‰QÞ™û*·)ÔãÆuuç\ ]—JuÓ•E/þ€T³E«*5`ÛÀŽ•ÉbÙG\w›N·ï&ù Ì•õ·:±wð¸ÇÖ…ô¤KG:”o’}?Éz1êžÕÏ±œTBËËý—øT¶ÞTXÕàŒTœˆ¢A>ú9Æ”ÞDRî‚Xç*9/±6EG)¤Ê¬åäSª÷`*˜Šd_±÷‚¹Ú»	¨ð$½µÉß‡÷!ë7)BÆ¨kb&V©/ ¹\ôœ²:Êà™e(!Ux@R¾¡×®Å;1…¨FQÝ0q1™8P®¦6ˆ Å:BÊ'tçRBÖéÑÝ‚	ŠÃû Ð¶ y¥]€”ˆªŒrñèTb.xŒ‘•…H H±n  as9rÑ) Ž‘m."–hËÐ¼Hd{¿Èò¬RK^uDÀ¤{qU»'Ðè‚¶ƒðûëˆÁq1·ªŽì>³~h]¯_L$À×k&QR£Êw[¼—^SÀ	ð«r2§ÐBznËÉ!È¯ÉÉû^.'«´LÌ6ûy¡s•	}4ÐÎè`&'2ùF¨@¨—9Ô+¼pžl¡Õ	˜ªø`¿­ScHä0·†Ê.¦ÊRÕk6àçÆÞ<^@“Ëqª.†'ÁàÁ¯úð\‚Æ›85Ý¶ø›D©¬R*{NõKEŒêìyOŽ•NèÄ^Å…6¶ôéí×5å¦:Ÿ­tñ9ÂJ]tì»ÞÍ.¢š‚Õ
+!lìÐcVhtböXÅyÖ(•[$…LÕ˜M(å¨a:sâb˜öAÝ°™9CDËTáÈ.²xµ¡÷ÎØ!{‰cXí6¹ˆ˜ArŒèsTßp%ƒôn%Lê;èä’ÃXåÇ¢mä$U5‚z_	²§¢´	s[p!åì³2ÀLä)s‘‹½Þ]^Šzçi´CV:T N0Iì0IÅó›âRJ8m³Ç ê…DcìMuÑCÿ’1oÑ°=¡ÒõbE*\ý¸ÆÊC£ƒ¦\ØÓOª>ØMR öH¨±râs¨m|6Æï7¹ˆ.aª&â¬Yôüf7MÖóÐXÔ`²ÂRâ„² þ®æL©=k*ývsN²HRÂÍaVÙ	ÖÈùð’Uù-uBJ”Û}E¨¬=Ô=ïR6DÏŸŽWÓ4<õ0»î-Ìø¾Í”™™Þg‡Õàw³xÖ¦{£	ÖþbÙÛ˜¡áj€º]i³]Úç¶Bb¾½—/†Î ž&N¿4é·8ë.Ð6Z8¢˜yløZ<8Ì°ÅA¯˜ù>—þê¿¢W*Ôèjt—[68¾x~— û“½•{lcÙÍ>Eðúi¤[°ô{o¶BZ·m™‚°~¯´}hÛ5îò ¾œ,•þmò-$G¡ú‡ó¥Ñ¥¶ôŽ¥I'Kòðüm9æÄlµ~Œ¤Ft
+©ëýŒkìì×]Úyïá¸}ßˆß}¿OB;cÜ~ÜÚ'0’:PæÞîçß.P™Ä8±lßp»_7×˜ô¾m¢&>*¥«@¯v GÛí¹Î`Þ¢©VÞ¹£€C§ …zÍë,0ã_¿^~BWŸ<Ñ[5ç«U 1Û¦-°&™ä`WŸè.;—ŸL=éeÑÇå¹KdòÆù‘ç÷z¾?Mâû Ùâ³S«\•ÅIHIôÑB!8„
+5=œCMïdð›æ\O%ûêÎvQŠ6­1þ~qíoÍÁˆq½éåa(éY-ˆìÃT¯"Ò/Çk™éLñ` xÝ‡üÒÓ¨J²Æ£J‹!Ò0,õ¤
+{6gÔß&èI‰côª«ç¥Xå9`PÉžÔE%ÊÖC,vJ¯1¼!H±)j˜˜þ^Úê‡1Hj#U€´“Ì¡À´oU©t4½É¦XPÑõ/Jµµâ«ŠVÁ¿¡S/jý‹Z‰cj(ôè,Ž9Mª'r ŒËh¨¾âPŒw/t1!ƒ?¶P+²„¢£œÔ]df
+Ej„Ö™C‚ÈjŽ6SŒjôŽ¢YpyèY}Ñ°,¨:çg%F1jÏ³(DÓ2(Ñ5ÄÎàå•hQ«îÄß¢:}ù½X°ÍŒøÒ¨Ä¶™ó¥sXæØ4°¬Ð\_Þìªù²–¾êùcýfwBog÷ÌÁî®Ž‹Ý…g»]'uvc·i0Û¿O–='eZCó?ÕÀž¼¾P¡-âŸ—:(èW¤K«œtS®xàz	Å<´ï§yµö«vèvVènZp§íø¡_ÃŸ†‰ªà#`‹¡8¸ØFõÐ—hÁ8²F4ðìäl:yß<HæèH4‰z¡‡5ñ+¥”WzØ"n:¹ =!©Ÿ<ñŽVó.‡9º =»¸ ©yk™3ªON£«Õ¨³ûÜ!zßqÿÿ‹•´„¦¨üŠ;CZšñL½nÀÐÁÃY¦ç«ô‘£÷&¢ÃTæyÐæìµt.rL.‹FîÌvåj‹õßb{GsKñ=©¨÷}5‰•ßÙâ¬µÐÕléó´7•kûiÜ•§`WÂ¬1doo:³q8KÍVw<éÙhì…÷»IIOÛP4H±lÈAÇÔó5HVQ—¤ˆVÒ%)rXNRä^$]
+GI—B#ØŠôwH«¨K¡´²’®ts@´R…‚®’.…‚¯tT\ú{\Ýñ™­zF3cim`e¤ºŽ¼ÿ•FNóaäÉ1oFò4ldÔ±F–í+†e11—ø(æÅ\âBó*åÁ-X)—HIÖð	CgÍ¢UÌÕôî¬Qƒvâè(æ‰¹DG1—¨¬$­b®BÍ6 £˜ÛF€UÌ­¸„lÅÜ³Ý«“:»«û<˜Íß§Ëžêƒ=O|”sÇJ…¶ŠOË¹”:s‰F•ÏF]Óø³\š{ch»»†q)˜6ÑÈÃÉ0't¾}OdáÞn¹+Ó‰,ÌÓŽyfœ¶vÔ71<_ØñŸ²×v›ïŽ«o¤Ø}ŸÁ%h.o¹“Ç:Žµà³7ü¤sŒyík–çv?ÒÞ>=ô‹Æ é6óî¶:ó)–úï3a0«¾ñ'–ÝûÚ6P·T~7‹÷ug¡¿”f.EWkMÜ‡ƒéÞl»¨0ág‡§Odicðô½dÓÝÏEcÔï
+ªtÚ£ñPô¹sÄ½R²Œß[‘­`Õ¨ù`<~}——×MÉmç<“gÒÏîtÇR*êù2wÔ°`RÂ}#zÒ'mõ@y”Ûøj´f*¨g‡¶rqûy‡IãaÙ‹>ZhÕ>Ôôp5=¼WUØ0Â°»O«œD}gœw=P‚JÌ™ÀKïî¯©S1õ{jà´2ß¾;YeURÉÍîNF¶a‰ËÞ2P³MçÐãî|R‚hY!ÑŽ†”@Qc„8,ˆ¨AÚôp}ÿƒ–¤çþëyÓŒE|êR ãýÁ»4y„ÕrZ¥™r(¢f’`Êðî‡28g§s/6~šÓš8‰ˆëiM¢B¥‹Ù j6³éáúþ[QË¤éönQ»ŸvkwL_²­K”ËýÛìPLÞ­ûsNrâ	6uIŸ#„§jØ§ÙïÓß^(³,ü¸€3;Hl;¹ ›NÞ-˜€4xû/L@>ýå‚	&Î¿#˜€+iêåjaUh€¶±)LMXh-¬„\,Xb,¬
+ÛÇ(ìhaU¨¶BcbUØÞÄª°Ä±ŽwÛšBakc-°fcÕ¤kcŸM»ÞìcZ íhÓV8ñš6Å‰ÿ´>ZJ§rÎÉ´gÎ¹›†O;ÉÓD:—cšRÇªaYPkeÕS©DÇÍv…hXÃb\Í¬¤w)k‰ƒ>Ì¬
+;šYº&PX5mÚI†3«BcÙì²AYLXÌ¬j¶Bog7œDL\ì6„C4¥ÎnmØ›YçtÙ£2'Öª¾öìõ¥
+mŸ4³†=worŸµÒ,á˜ÍL·¯ª:Ü=q
+µÝztfÒ?Ë…£–©BÒ¥×,ˆõ²l²4ÍX6¨×ú›®ƒ_ÛwrCðÁÜ‚bbî}Ò:ÛúmÍ'æ/ŸwqòÝZto&j—°vÓÁ¨<¤AŸVücÝœgã2ò‰³OìËOØ¾‡0dœ‰.Ø>;)¸~fg%î’Ù‚ì·u2-;*YyºSt—tûi6´c_{cw™ ¨“dm¹{Oó°‘îWK¿a¥8Ú$¾*µ	|Ìz“hÚ]f£P-Š!š+ZÍtÂ¸'yìðÑÍØöò¾±?£	ÑaGR‹ˆ´#ÉÀÜM?Wð¢Þ\%ŒÞq=ÝL›VúLÕÁ6¼Áû7ÈI´ÀÞá€=uáõ3-ó¾ßUµÂI
+û]5áëî™ý\Á?`W‘h
+uè®
+üÙm×_Ü¤Š j@&ÃwúÏ×%$€T˜+%xÊ;¾¶qTøI+O<Ä¿°q&#ð”üý£BVJÂAƒ’pÔ $œhP”Ä£%ñLƒ’xÔ $Â±vRQèAƒRX× $­ÔøÌˆì£#Ü›ÑŒ0ð2êÂÀß(†R£‚Œ91ªÊ˜;£Ô˜I6êÏX£&õUÃ² ‹%rÔ DŽ”ÈI86	5(á¢9ÈB(ŸiPÂGJ¸ô¾N2ŸiPå6ØiPÂe1yÕ j¶5(3‚Ý^»ù¨AêìÖîó`N 5(3±öPÉQƒKÚ2êT®•ÜY`ó/A	y§ ì"ùzÖŸŒ[Kzá-åd˜â×@ð~1¶|«?ãû—4]âKŒÄ¸Ÿ–)R+Ú1çÊŠc®z à×ÝØx4VÜt¤ó°Z|÷ððý\$¹™‘iÖqoò“¯sÞ-¼+[#S3ÜV”â!}X5¹iMôÕDÕä)_éã#[â;‘Ø<·âëƒ`-T¢TïH’)b%†<÷mM‹]6œÉ°ä>zèÙiÛ7zà$“`hº<ƒOÎ6îØqjÿE™»TÃH.”ˆ‹9ÿŸMKz)–(qÌ¨úL¤·ªä›àGÖzB‘:xtr¶¼×›FäK%)ÚH#7Ctá3‰¦GÇ",;ÓK¯'¼q=0¨~-úi“ä0‡´‹ÝçMðÖ®vFÔÓÛÅH°ß?ÍGÒ<·„´îqÔúX^][vwN¨ÝÊ¦‹ðìðS‰àª;œÜ'¯»lÑ‰ŸgW°×ê?¬oäpt¡‘‘w!³XèãÕã¡BMçÐÙÃ»š®(¨S›ôQ C
+ékhäµN«AÄB'Ò¶‡sè”wˆ‡Ó‡Â c‚ô³nì‚)˜HòU<e#b·\©{YécÀÔ¦u¢~;òa¾Žz;ò¡‰P—B‰uYx‰õ„Õ¢1C~û 9jÉ}}õ‰ƒ––Œ¹¾ë¨…ÖrB~\À„6\€M'ï{-DÐêRZÓÒC¢ÏR•—G,*l·\€ô¼}¨“>ûLn	`þíWÃÙ‘Á®Ž’uIêÜÔã¢Ø@ûãr#™ÂÏÂA+Øé30Ïæ
+‹Rþëoõ©Ÿô-Q!»š8#Ñ2îl”
+·æŠ<µºA¦Ñ¼LKÐ4£Ô³L–ŸÓ¯Æœ0ób1eæ½ÅTA{‹©ÂSf9XL¶·˜*ìh1UèÞbª°}Ì‰ÂŽ1'
+Ý[L¬YL¹ä¬MÓÛülšèfÓ˜×FÛYL'^Ó<8ñŸ†DKé49Î9™¦É9wÓˆÙ&ób1Ë1Í¢cÕ°,¨µ˜2ÓÁbª°½ÅTaÇ˜f<XL¶9QØÑbªÐ½ÅTaû˜… äÅbªPÅ7»lX‹iš­ÐÛÙMSG‹Åtâb·!,¦–:»µqs2§Ë:‰9™K`Ï‹i]Æ'cN˜Ç»·lj8õ½Åbú´ÔRyC¯:¶Ïï¯2ðÓ˜4,®_çgCï_7}©ŸSn•°’>ÿ!O™µñ½s`É“fµ§SqZÝ›8ŠXïæ€b»½¿aäBTWïœá½}Øf«w:¯Š
+zÙØ¤³q·vë0ã÷Á>£&c7~Ê;‚nž¦[·ièµµµÚ2~£!Îh£'8«ÐrQé¬=³O†Ù$|üîŸ>HÉÕô‰I‹ÚQµêpî.yMÐ[Â¹NlÍ‡ÄA›Ø‡sÁ÷J›DÀ‘Å9æàÆ&TÇ-tÄïþhƒ¾<HfŽáë
+:Ø˜mD•uÀ<´kã‹±ðÙ,ÔüqÕÝ°Ië&Œ#}öËZ^uâŸœØ“§ig¸³péÓ½#Fç£$„ ðó.ê;+Kªä ?®àØr#×N.À³“w{ŒûiŒy(}"ÛÉÑêm1N6”¾YÙ£JsÈFèïû‘Û£÷Jü>å*ÿd¶I/y£,)L¹XÜ“Å¡ðÖ—§øbú\I¨s€á9}Ù6}üóØÄ_£S7[ãócœî'-ó)ïøÂyMà\‚ÐK”!ræ¬nëN(¬«SŠÍ5þ¬—Kœ¼d+çQ/«—Kì}HVË%F²ÉóYî€B³V¶·z\ž¹œ×Üù™QFFÅÈg¹/£´üzc(5ŠÐ˜£0¹3ª•™d£„å0ÊÚX6,Kº(rù˜< 0¥š—Ñp”Ì³xÁ¡F‹ÂŠ\®áõiUärÄ«Èe8„¾(ìú¢Ð}è‹>Ëå¿‹"—mòÀlgwÍYòÀÄÅîÃŽ³Ý±“:»·ÉsºìYÁ“Ð—¾‹"—gò@]Æ§¹<’vuÞeIø4ÂDˆÉ%ÒJŸbp\jÛÿ¬)ÎX2Ž'øqkV‚&%<.}œCMïj3Ž¢v]Ñ7£,5‘À‰OúœEÅ‚'Þ¶sè‘š7Œ«ÿ…sÁÂ× ”Ï"‚èÚÔ}:A–$ƒ{9è…g•ÖNKä¿‘€ƒ¾½¸;é9@˜|¦nKî/Å[^. ‘–'/QºJÅÆý³G!Õ6êP¬^°b`o"~"çrpÙÇõÂÑ@sJ-°~9w|žÒ¥›ðûŸ^u<C•õ-ÆÏfnð¿I«`MÍEª_Ýk´
+¦ÂÝ©Îÿó´
+Û&¼£VÁ¯TÒnæ8ï¥U,åm„ëY©±g\ÌÃ.¼¼±qÓ`#°Os[BIo¼»²XÜža O½üÈ¸×ðz*y©0jbf­ó¯'.Î$Å•¨^ëÊ^}(æ)Óí¯ÂHeZ¨FŸÞà´¯A¶¯_öR¼¤šC^r;–Y’¾©ítÒkOÊÀÞc¤>SxXrK!
+ó¾ÏÚÌö{·7$Ïˆ	‰oÃ²µ$V½pô•Ó}¬–mE#CY›¹}¤"Ý‘”Âc“õ}Þ›Æ¤¥U¼¸÷‹a_NîýüF‘=)·š;k^_eÆ½S[A{cˆÂTOÖ"LcˆÂTÍ´>B…Ú
+ÝC¦F«Ö*LÍa1†(TÁC
+¬¼ö¬¿¯¯2ÌÏ¦òÝúXœÚm´S»áµ8µ'þÓD`)Æ„9'Óè0çnš'ì$OCÆ\Žið«†eA­-D¸ûçÍv§¶ÂŽNmáúÐÀf±/¯CÐ¤ÓŸø´J9•oÎ™óSˆÂŽ¦…î}ÚÂ¾¬åú*Cšà>m;‚Ý]þ`
+™8ÛýêO|ÚsÌh³e
+œ¸´çØ“×*´E|Ò"¼
+_’ÜM9…})…ÅõT‘ÍgºÄ!ãê,›HgâøÆßÝË}â<}n‚3ïò¨Qo;Ü„R“‹çÜ·×LuW+Qíß¨óœvoó*ÕØRVê¢"¶ßÇg·Y}è…²ú.0'Bôa÷ü˜ì}-Þ«šÈ~õþ>éße
+ßÃ§s>‚†âfb"}®)º@¡D™‚Ö·öA_ÞàÇœ¨„Š°éä<;yßº	Dà‘f¬[z’æId^é±`ƒ¸íäüQôpÈZû_ßf¶ô°d'®ôX°AÜvrþ(z…ò†p^é	]‚¤öQKÄm'à¢G£ýÍÅ0ä ‡à(¤XÛÎ¡RÞã–j0ÒÊSËü,®“úcoBíFS2Šÿ½áaeK=*ø¬œïjÌu™ç¹nô›ßoáwš'ˆYÑw/‘Cð¦2ô±Ø-ËºðÏ‹Y°möUUoZßè•â0+¾&PÁoúêÙ3#¼í]Œˆ9ÌbCÌï™ V]\]µA€­2®nÙ½2®NÙ}„¹d,ŠN²Ê¸ºe÷Ê¸:eÊxÆÒJ¬2®®Ú]„¹”§™ÊxÆ£2®°®ŒG¯QëÆgFý}EÑŒfTÊ—Q=þFI5”uvÌ‰ÑzÇÜýØL²Ñ¤Çr{,–%]´ñìÚxöGm<û3m<åCd‚Â
+Õ–Ò”ÏÔñ”ê¸éRÚYNy€›õHù¨ŽkD@ùï¢Ž+tî…ÑÎì3‚Ù_³ÎfÇêÌÞó0À˜.{Vü™>>–Àž>?õñ²ŒOëã™÷vÅóÞƒLþrÔ¯Ïªó­ýHZƒGÍó²ezÅôâÐÄ]Á…òa*áX»DojZ‚†¨3µÃŽ§éHi>~2á¡Âëˆ"pˆIðPE¢;b©?ÍÑíã%êê]‹ æÚ×Éiõ¥éØU6ì,/¬ðKeÃ®f[ë»ìØÃÞTbré/žV;ÛˆÁ÷¬.@uß”ø‹NŸzš§'ùãN`ºzÃ~º^.@îO«ð[ þpÄÓ–öÙh?|_É–‚Ð¼yBGÞ(²Aª%ŒÇòilYK|Rðåýb_Þ=Ø~ÞåÕÁú¸BC©L¡PÛÃ9tôð^º’ºÇŠv¤†e·a~»®tZc¾!<7+ÍSh­qóÔ½UÌ­8)EæØSU´4Ý3ú°9
++{`ï]“•]ú¶õšæª 4f˜Z1 ­«/YÌ+­Lè'*/Í[9]}‚áòîãHˆ&_j”#ÒÅ€&A´f"‰j®Yå’ÑktzK¨:>W-ÄI&°Jœ3Xy¾ª‰CqÛ9Ë—<œ®£^¾4wƒGÌC2‘xûÝç#Çf‰“ùØBÏ{®88ð·OuŸ‚Gqõ@Tßr(Uo}p¬ñºú¸B“Ë±AmàÑÇûZµôsÒgæ-5 h¡ç9x"¾trþ zP‹¤ yÃ–”¢ê+ž–ž<_:¹ =Zs°^‚=ÄéUÔ<KÏžˆ/\€?ˆñYŸ}RíÖÒÃÙ;ÕÅ×­¿‚'âK'à¢'eÕ+–}¥¥Ó¹ Ä+5:±¶=œC÷¤¼¹tõ±)ÚBLƒo5á?‹tub‰6w¾2V\™Õb¨»xqqñW^…¹íÛX¨o•ˆ¼éˆÞY¨ßÏ)þ«Õ@B¢¶K¦x1ŒÎ\Bâ·‡7	s=“«²}K‡ÂÇËT÷-{Òn¶ò'Ù%T«Ù^"ŽŽ¢M‘,fì0:(k‚-YÚšÐ³é³
+”‰ã°v„O&¦¥¤5Ñ”GØÅ%ðÚw
+¥„™Zfôqt>T¨éá:{xW“õ¹ÂDåqoCJN„ÓŠˆ…N¤mçÐ"%‚ƒj±7¤dM}É%,Î b¡iÓÃ9ôƒHà@<¬´ pp!¯¨,à‰÷ÒÉø£èÑšÃzb€@CÁ™×ÅYÀqÛÉø£è	œF²Ð(9IYËYz,Ø n;¹ =ÉkÖ¼àJNLì(Òz†-Ô`mz8‡~)X^‚!Ê)èµÜTTí× b¡iÛÃ9ô@Ê›—]P[iáŒ¼1¥–wóyEæ‰ï¾žc/Õ2ÞJÂ‹èÃ'ŠÙí=	O
+Òi~wÿVüKê-ï*½Rÿu{¤a‰üÆ£„ÔÓ9¶ZŸÎ‡‰ïC’½)¾¿¸œÞ•øe„ÉoßWÊF’™McËÖŒ7._W±°#s¢Âj‘1‹ÉxZáËtØ\ž4³eG®NÚÇÃ\%&²«Ï„Î±.}w¨8I_¨_|mzÅ¥~ñëÛtâ¾lÓ¼Û¦eë¾½«#¦>:…KWÇµäáÒ9qÝæÒ	ò„«ãn˜^…ôè¡«ÎžðÜÈå'×SpåŸù,n ³%˜ž:æ›#ˆasA8—-v ^Þ…Ü‚>“…Ô¸§þ½Un˜éœL<ýxQ­I,wÁw…ÂæÊíìû¾Ío	ÖgWÆ>2±ÃónêÎa0fèß¿QgÎCMŠœ ˜;ÿÛñ0"Kly¶þÝ¯íšOöY‚‹²ÃÝ¸ƒ?}32Ä·™]QÆÝ•Tm¾ÌäÜ«=v‡¬YyØùÈv[žd×ª?Ðò}]Fê’Y]®„Ž2â¡Ã½í“¾ÔŠ[àv¡2œÌ&irUOP˜ÙÈÉûý.¾ÊÙïr‰¦0‹|3g³››”‚èþ‡¼yž.ªï-[­M¶=üý|ñ‰D¡3‘óì•ïA±}÷ÑB––q´’èFrÅàR)†1çèæ’QÏUžmv‰®ñ»ì\¯_ÇÖ*!³¯uÛüvC"ˆ¾ÙÉ5p9±åa}ùÓèã
+ÍÞe¨PÓÃ9tôðŽã´+ýF¸`ÿvmõ¤ÄÀl-õQ’õã¹8hìír ö"üªfDl«N4&w;ƒÜ4™çé<Þý­„ZT¾76FçL±0”°òÅr™~yžH ¾T+7Öè#„‚RÏ¨”™ãžsÑªIe—|ldÆûMJŒ	fLÍW“¥;îò7`·ö+4JGìiBeØÂ*ÏØ¡ñù€ŠÉžN|Sû÷ß^Â]‹Äš®£ƒÆðÁa­¿º¼°7[™Âà§A;ù`y­¤ðÞgH2bÄÙÔ,¶/u=•m#Ÿn¥æ–¸K=ÒcÐ›[ `T¬0¨†ùlÁó8hÕ£•;;ûd<¤äÄGŸ6ŒZË“¾¾¬•õrÐ;mB-4yU}+töp5=¼ÛÓHÁõ¥–¿ ·øò;spÈÉNÁëy8úÜj6ëT?‹‡Û&‡‘÷ááqÂ/ñð#‹M¦ó`­@=oŽë÷zòÃ±nT7·“ƒ-NÀ«ò4Ì–£¤~x*û>»Ì2(ßÌ÷SýÛÈ0‚zïE ­¢‡«:¬Ä&³6jÇH¹©•ß[>G7ËÐ>>ÄÒ½|lVHgµßLzšÒ"ý>Áì‹±BD#ãù3ñèÆ>H[JCÚÿÒo½¼Ê‘^ éìÕý‰3'4÷.¬!ÒÒ"iöá^8yB6¢´FFÛCv–3}õ†Â™µãê­;&Ÿ9Áì[ÁÃñÖR³’Ë9ù5§L%	è^œeÞW	#by:Ó¸Þ'	»m”¼»zjÆýœq{ÅÖù¾U¨O)íT&Ì^v–’–j7­^œÐ9þìê“‰Y”4Ÿ3o˜…ôÑ_-ÁNº°!z}\¡¹öó¸öp=¼×ûªÃm›}øˆY_¹-f½‘ð‘qˆúñÍ…ÙùÇ
+sÜÁ4M*e?ýw¿™ZÊK²úÎ\Ò$v	—z~	“è#Á¤`©’acšy^žŽ¢Í‰B0bL±Wó#º¸a©"ZÜáèûÜè"ßï<A&ÙöMX±ø&tÏ5ù«¼Šý^À#öàÉ·³/¼]k‚W™Îo×/±í6Oi$È§°Ê¢ö•ZcÀ°lø¥Æ
+Ô‘Êš²®©cì‡sNÚåc»´2ãKŸÛ}6¦ÜK°Ld>ÖO7ò\ÁVc8svY"&~Ü³+^¸Ç]'àÑÉ{UÿÎÑéªÃ_€w\ýMþ«¸ÿ?9`ýÞ
 endstream
 endobj
-58 0 obj
+60 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -554,7 +563,7 @@ endobj
 /S /URI
 /URI (https://arxiv.org/pdf/2403.17218)>>>>
 endobj
-59 0 obj
+61 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -564,7 +573,7 @@ endobj
 /S /URI
 /URI (https://doi.org/10.48550/arXiv.2306.07487)>>>>
 endobj
-60 0 obj
+62 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -574,7 +583,7 @@ endobj
 /S /URI
 /URI (https://github.com/ARiSE-Lab/TRACED_ICSE_24)>>>>
 endobj
-61 0 obj
+63 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -584,7 +593,7 @@ endobj
 /S /URI
 /URI (https://doi.org/10.48550/arXiv.2212.08108)>>>>
 endobj
-62 0 obj
+64 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -594,7 +603,7 @@ endobj
 /S /URI
 /URI (https://github.com/ISU-PAAL/DeepDFA)>>>>
 endobj
-63 0 obj
+65 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -604,7 +613,7 @@ endobj
 /S /URI
 /URI (https://arxiv.org/abs/2311.04109)>>>>
 endobj
-64 0 obj
+66 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -614,7 +623,7 @@ endobj
 /S /URI
 /URI (https://doi.org/10.48550/arXiv.2212.08109)>>>>
 endobj
-65 0 obj
+67 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -624,7 +633,7 @@ endobj
 /S /URI
 /URI (https://github.com/ISU-PAAL/DL-VD-Empirical-Study)>>>>
 endobj
-66 0 obj
+68 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -634,7 +643,7 @@ endobj
 /S /URI
 /URI (https://doi.org/10.1145/3460319.3464832)>>>>
 endobj
-67 0 obj
+69 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -644,7 +653,7 @@ endobj
 /S /URI
 /URI (https://dl.acm.org/journal/tosem)>>>>
 endobj
-68 0 obj
+70 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -654,7 +663,7 @@ endobj
 /S /URI
 /URI (https://link.springer.com/journal/10664)>>>>
 endobj
-69 0 obj
+71 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -664,7 +673,7 @@ endobj
 /S /URI
 /URI (https://conf.researchr.org/home/icse-2026/svm-2026)>>>>
 endobj
-70 0 obj
+72 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -674,7 +683,7 @@ endobj
 /S /URI
 /URI (https://conf.researchr.org/track/fse-2025/fse-2025-ideas-visions-and-reflections)>>>>
 endobj
-71 0 obj
+73 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -684,7 +693,7 @@ endobj
 /S /URI
 /URI (https://conf.researchr.org/home/forge-2025)>>>>
 endobj
-72 0 obj
+74 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -694,7 +703,7 @@ endobj
 /S /URI
 /URI (https://ieeedistill.github.io/)>>>>
 endobj
-73 0 obj
+75 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -704,7 +713,7 @@ endobj
 /S /URI
 /URI (https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=10206)>>>>
 endobj
-74 0 obj
+76 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -714,7 +723,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615)>>>>
 endobj
-75 0 obj
+77 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -724,7 +733,7 @@ endobj
 /S /URI
 /URI (https://github.com/ISU-PAAL/DeepDFA)>>>>
 endobj
-76 0 obj
+78 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -734,7 +743,7 @@ endobj
 /S /URI
 /URI (https://github.com/ARiSE-Lab/TRACED_ICSE_24/tree/main/tracer)>>>>
 endobj
-77 0 obj
+79 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -744,7 +753,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/cfactor)>>>>
 endobj
-78 0 obj
+80 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -754,7 +763,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/tree-climber)>>>>
 endobj
-79 0 obj
+81 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -764,7 +773,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/pal-tools)>>>>
 endobj
-80 0 obj
+82 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -774,7 +783,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/rrun)>>>>
 endobj
-81 0 obj
+83 0 obj
 <</Type /Annot
 /Subtype /Link
 /F 4
@@ -784,7 +793,7 @@ endobj
 /S /URI
 /URI (https://github.com/bstee615/wslwatch)>>>>
 endobj
-82 0 obj
+84 0 obj
 <</Filter /FlateDecode
 /Length 7374>> stream
 xœÕ]Ûn]9Ž}?_±Ÿhµ(R7`0@Å•ôs
@@ -826,12 +835,12 @@ endobj
 /F8 8 0 R
 /F10 10 0 R>>>>
 /MediaBox [0 0 612 792]
-/Annots [11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R]
-/Contents 56 0 R
+/Annots [11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R]
+/Contents 58 0 R
 /Tabs /S
-/Parent 83 0 R>>
+/Parent 85 0 R>>
 endobj
-57 0 obj
+59 0 obj
 <</Type /Page
 /Resources <</ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /ExtGState <</G3 3 0 R>>
@@ -841,23 +850,23 @@ endobj
 /F8 8 0 R
 /F10 10 0 R>>>>
 /MediaBox [0 0 612 792]
-/Annots [58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 76 0 R 77 0 R 78 0 R 79 0 R 80 0 R 81 0 R]
-/Contents 82 0 R
+/Annots [60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 76 0 R 77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R]
+/Contents 84 0 R
 /Tabs /S
-/Parent 83 0 R>>
+/Parent 85 0 R>>
 endobj
-83 0 obj
+85 0 obj
 <</Type /Pages
 /Count 2
-/Kids [2 0 R 57 0 R]>>
+/Kids [2 0 R 59 0 R]>>
 endobj
-84 0 obj
+86 0 obj
 <</Type /Catalog
-/Pages 83 0 R
+/Pages 85 0 R
 /ViewerPreferences <</Type /ViewerPreferences
 /DisplayDocTitle true>>>>
 endobj
-85 0 obj
+87 0 obj
 <</Length1 21772
 /Filter /FlateDecode
 /Length 6890>> stream
@@ -887,7 +896,7 @@ r,ºô4;@šŽtOµ:B«5…L1ECŽF2==…!]¶§/î±æ»¯p’ÛZ–b.°fð•Ú8ZM«¶1h-Q¬™jöPçßû›rMçŸø
 õÄpPÁÆ‹ì™ÿo}L"‰$’H"‰$’H"‰$’H"‰$’H"‰$’H"‰$’H"‰$’Hâÿ-PQ˜ó?aïÚ°
 endstream
 endobj
-86 0 obj
+88 0 obj
 <</Type /FontDescriptor
 /FontName /AAAAAA+LiberationSans-Bold
 /Flags 4
@@ -897,11 +906,11 @@ endobj
 /CapHeight -687.98828
 /ItalicAngle 0
 /FontBBox [-481.93359 -376.46484 1304.19922 1033.20313]
-/FontFile2 85 0 R>>
+/FontFile2 87 0 R>>
 endobj
-87 0 obj
+89 0 obj
 <</Type /Font
-/FontDescriptor 86 0 R
+/FontDescriptor 88 0 R
 /BaseFont /AAAAAA+LiberationSans-Bold
 /Subtype /CIDFontType2
 /CIDToGIDMap /Identity
@@ -911,7 +920,7 @@ endobj
 /W [3 15 277.83203 19 25 556.15234 36 [722.16797] 41 [610.83984] 48 [833.00781 0 0 666.99219] 68 72 556.15234 74 [610.83984] 79 [277.83203 0 610.83984 0 0 0 389.16016 556.15234 333.00781 610.83984] 92 2015 556.15234]
 /DW 750>>
 endobj
-88 0 obj
+90 0 obj
 <</Filter /FlateDecode
 /Length 320>> stream
 xœ]’Énƒ0@ïþ
@@ -924,10 +933,10 @@ endobj
 /Subtype /Type0
 /BaseFont /AAAAAA+LiberationSans-Bold
 /Encoding /Identity-H
-/DescendantFonts [87 0 R]
-/ToUnicode 88 0 R>>
+/DescendantFonts [89 0 R]
+/ToUnicode 90 0 R>>
 endobj
-89 0 obj
+91 0 obj
 <</Length1 10124
 /Filter /FlateDecode
 /Length 6779>> stream
@@ -956,7 +965,7 @@ Vðûýþ,Ö)&êj×µªE´R]˜‡k@jT+YÿÖæÞ^<ÿ^|¾‹ŸÝßHŸ¹%ñÂ¡ï$×€sU»®+I ZyÛ±^¦qÆ
 hð/xJÀÜ*àC68K¥¦¸æßQÉGTòF—	¸H@‡€W¼¤aØ!`rAe ü³€ç‡Eoð.§ª$£€¾«*í”€ûÔ‘mªèŠaÕÒÕ	’ÓïWõJRªÐ‰~ud·€E#1‹,„d¦Q¡~Äš£ÌÙ:B!ÞÀp\;œŸ‹‹ý#ÙIõÎhN¾œºØä9©íïX"K==m©‡ŠNÒIXÒûæ1æ $AÎÜy÷C]¹äŒ½ëö?utIËúMÄágî—÷m'«_L{|‹bK—ßuOäè;JŒ?sÿ‘ïmOî:ùµr *Î6ëti“–ãÈ5ÛÀF‡$›É`Lë@.öç¢œ‹—Õ{"sq¹/[roJFÃ+¼!¹F%¡Ñ+³²¤oòÒ#;{SK™ûÜGŸ'ßµ~êÑg¯ëßRÛsf¨P9m”J†Zi`ƒrÑÃ2éÀ@–]›’´&Ò’HÛ>;vÛ±ÝŽ-vŒØ1dÇ";^°äœ‘CräåMÉ·J×ÍuÊŸ}z?þÛ_}ô™g·o}êû[‰±ñßÅÿˆ.d‰¢ø¥øƒïœûõû¿€¤5‰-ÔBÈ^41™™ z‹ÕÈ¤™(c2}x½£¦ô*V°YU#dY“{úsPK	-+Ç»ÇÏnYOÎmíìso]™ö|Úë½Cg Á—¸H§*`24ˆ³5Ì8k®Ã à°2”à1Œ#ívgHÊµ›È´¤!m&‚/{pÐƒýŒx°Ýƒ~š<8r|‚ß«#•Üe‚Z—ôy…X@”Læ½©¤'Éãÿ9ðöy×Þ¬îöÇ7†—wìÞtë{o{/÷ûÆMkl+ªûN×†QØõÂ£ÛwT.^,†rÆM¼}mhÇî[-å·ßZQ0{²{üœ[£Š‰ËÄdÚˆãKºÑ¨£(›5ƒÖÒ!)Ý¨C=©µFÂ¬Tªí6µx»?çl}]íÈ‡5¦Š•E¸~\	Ë—x§{­^+Ÿ,»‰ÉRí¿csÉýo½åõ/ÓÚ?'þmÓ•+›†jú3-M\$?¡fBÔ‹³ÌZm:f§gç:Ì´6ƒUÆÿe`€÷ÆCšµ¤Þ ½¬%‹/ &¨…I^	‹3¿ÔÌ¡*52ˆØµ—®Gñ3€ÿmà7!
 endstream
 endobj
-90 0 obj
+92 0 obj
 <</Type /FontDescriptor
 /FontName /BAAAAA+LiberationSans
 /Flags 4
@@ -966,11 +975,11 @@ endobj
 /CapHeight -687.98828
 /ItalicAngle 0
 /FontBBox [-543.94531 -303.22266 1301.75781 979.98047]
-/FontFile2 89 0 R>>
+/FontFile2 91 0 R>>
 endobj
-91 0 obj
+93 0 obj
 <</Type /Font
-/FontDescriptor 90 0 R
+/FontDescriptor 92 0 R
 /BaseFont /BAAAAA+LiberationSans
 /Subtype /CIDFontType2
 /CIDToGIDMap /Identity
@@ -980,7 +989,7 @@ endobj
 /W [0 [750] 3 18 277.83203 20 25 556.15234 29 [277.83203 0 0 583.98438 0 556.15234 0 666.99219] 54 [666.99219] 68 69 556.15234 72 75 556.15234 76 [222.16797] 79 [222.16797 833.00781 556.15234 556.15234 0 0 333.00781] 87 [277.83203 556.15234]]
 /DW 500>>
 endobj
-92 0 obj
+94 0 obj
 <</Filter /FlateDecode
 /Length 327>> stream
 xœ]’Ënƒ0E÷þ
@@ -992,10 +1001,10 @@ endobj
 /Subtype /Type0
 /BaseFont /BAAAAA+LiberationSans
 /Encoding /Identity-H
-/DescendantFonts [91 0 R]
-/ToUnicode 92 0 R>>
+/DescendantFonts [93 0 R]
+/ToUnicode 94 0 R>>
 endobj
-93 0 obj
+95 0 obj
 <</Length1 29888
 /Filter /FlateDecode
 /Length 12576>> stream
@@ -1054,7 +1063,7 @@ T<?G ^Œ#)’:Ö
 3âow½¯Ïhï2oë?d÷}KÑË¼ºxgÕSë´ŸÊû>Ò•
 endstream
 endobj
-94 0 obj
+96 0 obj
 <</Type /FontDescriptor
 /FontName /CAAAAA+LiberationSans-Bold
 /Flags 4
@@ -1064,11 +1073,11 @@ endobj
 /CapHeight -687.98828
 /ItalicAngle 0
 /FontBBox [-481.93359 -376.46484 1304.19922 1033.20313]
-/FontFile2 93 0 R>>
+/FontFile2 95 0 R>>
 endobj
-95 0 obj
+97 0 obj
 <</Type /Font
-/FontDescriptor 94 0 R
+/FontDescriptor 96 0 R
 /BaseFont /CAAAAA+LiberationSans-Bold
 /Subtype /CIDFontType2
 /CIDToGIDMap /Identity
@@ -1078,7 +1087,7 @@ endobj
 /W [0 [750 0 0 277.83203] 8 [889.16016 722.16797 0 333.00781 333.00781 0 583.98438 277.83203 333.00781 277.83203] 19 28 556.15234 36 39 722.16797 40 [666.99219 610.83984 777.83203 0 277.83203 556.15234 722.16797 610.83984 833.00781 722.16797 777.83203 666.99219 0 722.16797 666.99219 610.83984 722.16797 666.99219 0 666.99219] 68 [556.15234 610.83984 556.15234 610.83984 556.15234 333.00781 610.83984 610.83984 277.83203 277.83203 556.15234 277.83203 889.16016] 81 84 610.83984 85 [389.16016 556.15234 333.00781 610.83984 556.15234 777.83203 556.15234 556.15234] 95 [279.78516] 153 [583.98438] 2021 [277.83203]]
 /DW 500>>
 endobj
-96 0 obj
+98 0 obj
 <</Filter /FlateDecode
 /Length 331>> stream
 xœ]RËnƒ0¼û+|L‘mMRAâÐ‡Jó/ÔR1È8þ¾b—&RØšñÌîØ‹ÈÊ¼´Æsñá†¦Ï[cµƒi¸»ø:c™
@@ -1090,10 +1099,10 @@ endobj
 /Subtype /Type0
 /BaseFont /CAAAAA+LiberationSans-Bold
 /Encoding /Identity-H
-/DescendantFonts [95 0 R]
-/ToUnicode 96 0 R>>
+/DescendantFonts [97 0 R]
+/ToUnicode 98 0 R>>
 endobj
-97 0 obj
+99 0 obj
 <</Length1 32640
 /Filter /FlateDecode
 /Length 13633>> stream
@@ -1151,7 +1160,7 @@ c$))V«1µZ ]ö7åbc.®ÈÅº\¬ÎÅŠ\Œäb-ìÐIm7êÅ˜mµQ¿c"lx¡'W[:µBÛ"m6®ËIÒN¤`Ü¡
 ¿{Y­^³Lh¼‡ÿ)ÈæµnNéñ¹ø:³ýìÏnÒþªöX òˆv§Èç^@$¼Ž5xÂ’H”5£ y³Àù¡q—7q¥±ÆˆUFG#ýŒè3¢Ãˆ`ÄÓFl1â‡Flúü?Ýˆ¬µ‘m¤hu¿…æ ˜NSì(Å*ŠÄÒ&ÛA›L $Zj1"ÓL™Rhk+hÌ$BcÇƒåÿéÆíb©þJ¦ƒ/O¡¶…^œc™²Ö×‰¥õq&¶„d.]rî/K!‡áË¸›yÄÊëÆ0îr˜µ@Êò ñwÒñ5vs%è+wFû¾ÛQ3z1Œ£ÍÆ0ÎÂmx9”3ƒEÙÁóß€³æùì|mÉ’$%´Qb¨«áÿ%´Qª%{±ˆF©²`u:£A'¬-Õ‘M¥:¢}åµã7Û¾5Â¢ÄWØ“3–Ë‹o]£µ_ÆÌ#@  ;ç5ae‹AÙœ™à£ý;zvú|ù¯…ÿ²„b
 endstream
 endobj
-98 0 obj
+100 0 obj
 <</Type /FontDescriptor
 /FontName /DAAAAA+LiberationSans
 /Flags 4
@@ -1161,11 +1170,11 @@ endobj
 /CapHeight -687.98828
 /ItalicAngle 0
 /FontBBox [-543.94531 -303.22266 1301.75781 979.98047]
-/FontFile2 97 0 R>>
+/FontFile2 99 0 R>>
 endobj
-99 0 obj
+101 0 obj
 <</Type /Font
-/FontDescriptor 98 0 R
+/FontDescriptor 100 0 R
 /BaseFont /DAAAAA+LiberationSans
 /Subtype /CIDFontType2
 /CIDToGIDMap /Identity
@@ -1175,7 +1184,7 @@ endobj
 /W [0 [750 0 0 277.83203] 8 [889.16016 666.99219 0 333.00781 333.00781 0 583.98438 277.83203 333.00781 277.83203 277.83203] 19 28 556.15234 29 30 277.83203 35 [1015.13672 666.99219 666.99219 722.16797 722.16797 666.99219 610.83984 777.83203 722.16797 277.83203] 46 [666.99219 556.15234 833.00781 722.16797 777.83203 666.99219 0 722.16797 666.99219 610.83984 722.16797 666.99219 943.84766 666.99219 666.99219 610.83984] 68 69 556.15234 71 72 556.15234 73 [277.83203 556.15234 556.15234 222.16797 222.16797] 79 [222.16797 833.00781] 81 83 556.15234 85 [333.00781] 87 [277.83203 556.15234] 90 [722.16797] 121 [333.00781] 2015 [556.15234 1000] 2021 [222.16797]]
 /DW 500>>
 endobj
-100 0 obj
+102 0 obj
 <</Filter /FlateDecode
 /Length 322>> stream
 xœ]RËnÃ ¼ó›CÆqH–¥ÆŽ%úPÝ|€k©Æ“ƒÿ¾‚M©XÍ0³ì.°ª­[£=en–x:h£,óÕI µ!‰ JKCq—So	«Úº[Sk†™¥ìF½x·Ò§5_`CØ»Sà´éÓ¹ê6„uWk`ã)'eI„U¯½}ë' ,Ú¶­ãµ_·çª{(¾VTDœ`5rV°Ø^‚ëÍ¤àœó’MÓ4%£þ§èºò»wQ–´à\ð2 üÑ1(?e%-O1ÓÍ³ÿËð¸pM½"‹™øÉ
@@ -1187,10 +1196,10 @@ endobj
 /Subtype /Type0
 /BaseFont /DAAAAA+LiberationSans
 /Encoding /Identity-H
-/DescendantFonts [99 0 R]
-/ToUnicode 100 0 R>>
+/DescendantFonts [101 0 R]
+/ToUnicode 102 0 R>>
 endobj
-101 0 obj
+103 0 obj
 <</Length1 27396
 /Filter /FlateDecode
 /Length 11417>> stream
@@ -1241,7 +1250,7 @@ f,äb£xÉ¢1jƒ–ÏqRš™n7ðt€½±Íý­~"øÑËÞíÜÈÿ‘ÿ¢Ÿóù‡ú	øM~rÃE?žõãG~”ü8ÊßêßèÜÏ˜
 tÅO}æÝìž·­Ù8ó‰¶¶Qß|ˆÓr³/¼añ=ý+×,m/Çkvî»íÎÁµUMuÃ'úWÝtíº­Qge°²¼ÿÜÜ~ãå· uÑó¤Í‘¦ zt…Rg$™’ˆUUuH§Ñj5F°õb¿¹çå›¹W sPA‘âá¸ çí9Á µ¦Éxç’¤¥³ïð¿ôöÝ”þC¬Óm3'U5Ë¾ÿ~Y×¢aÞZÃ=‰2U'E¿c®c†€®Si¢Ú¬1Ä¥99Åd»!A££¢‰íë¯È0Æ_Øíàöœ¶Š¬¸í×e˜ÒµH‘bRyo/)&ò- Ì4fè`˜(È¸æ§çu:ƒ`U†6£1)1BÜ´+goóU/º=Ê	ÚE…EÀK?ûâ–IÊÍÃ¶×™!]â¨ÖAƒêkÉk€0@5Hþß'p Xh4ôTÅñµZ<U›[gC=µÙUv»=h¿Ý~¯}“]õ•Ÿ··“f;Úeg#köÍå;Þ`§Í(¿ÝŽ!;ªìA;¹hÇBûLû&û'v&=ÞwDYyùÃö]öãvz¯GÉ=3í…vZ´Ëþ;ÙdÇbûh{È¾ÀÎØíøo;~bÿÊNfÛØï·ÓByRe]Bbùz;ÊßZU¸yC¹Ñ^b'œÍjUôzµ™§<§QQÅ%Ä‚%ÝA,jQ_çk¨kˆ+zL”/VðÕ+ñŠ¹æ@ÜY­ëe›ò2gP	WÈ¡!«=¡LÎûªÔ¼ˆtêúý¸j¬y5GåÁ»%òÂùŠ¹]vfH—çÍWÈ×]Î›ÇWÒI€Ñg ˜aÌàaºèQ¯båxË §åUªÑ›ô‚žˆú*ýY=ÕË+µç-×¨Õ¬–AùG¬Q‰X$\‰XÄó>õÞ¿Ùq¦JØÂªøM¯½¹û-<ùéåW±þ½ˆøRdÉ!†ÈT|¢ëb×€Ñ•‘ÉÌÌp@PL·Ø4F^kÔZ­Nù½á©Õb1jx­Ñ¦¹ÊéïáÍX¯;”–?0ÏšÖíæÓ€5•@ˆ©|˜;WhXt}ú\‹1	µ~«kõœû6D&îU·-ô3ºvWvÙE*\zóÕÍce‰9J;ñsùú2¼–ïŒŠ¢aq[ùëüGü9žà‘ïŒ¶=Û:¿|Z,+Ž™3¯ÜÎ#Ãã-Ÿóßóä/÷¥;y\Ëã]<Nä›ùVžŽä±€GÂ[ø4žžã/òäð¯ñäqçñwñëy›PW9¡œám<¹‚¥´¢<ŸÈàM<¹æn¥ú¨h/VÞ›Ÿâå)éÚx“+ÅSž'ãdãÓyz7Ãži‘P†êŒåò/_ü<ÕP–yt*»¦²òËmÅŽûdÊ‹µÅ^Âøz{XñW3>å-©l‘¼…EÞ¢ g@ºh~Rmæ±dËHÚ¹|ñë ø?¥wÕ”
 endstream
 endobj
-102 0 obj
+104 0 obj
 <</Type /FontDescriptor
 /FontName /EAAAAA+LiberationSans-Italic
 /Flags 68
@@ -1251,11 +1260,11 @@ endobj
 /CapHeight -687.98828
 /ItalicAngle -12
 /FontBBox [-664.0625 -303.22266 1360.83984 1014.16016]
-/FontFile2 101 0 R>>
+/FontFile2 103 0 R>>
 endobj
-103 0 obj
+105 0 obj
 <</Type /Font
-/FontDescriptor 102 0 R
+/FontDescriptor 104 0 R
 /BaseFont /EAAAAA+LiberationSans-Italic
 /Subtype /CIDFontType2
 /CIDToGIDMap /Identity
@@ -1265,7 +1274,7 @@ endobj
 /W [0 [750 0 0 277.83203] 9 [666.99219] 16 [333.00781 277.83203] 20 25 556.15234 29 [277.83203] 34 [556.15234 1015.13672 666.99219 666.99219 722.16797 722.16797 666.99219 610.83984 777.83203 722.16797 277.83203 0 0 556.15234 833.00781 722.16797 0 666.99219 777.83203 722.16797 666.99219 610.83984 722.16797 666.99219 943.84766 666.99219] 68 69 556.15234 71 72 556.15234 73 [277.83203 556.15234 556.15234 222.16797] 79 [222.16797 833.00781] 81 83 556.15234 85 [333.00781] 87 [277.83203 556.15234] 90 [722.16797] 2021 [222.16797]]
 /DW 500>>
 endobj
-104 0 obj
+106 0 obj
 <</Filter /FlateDecode
 /Length 324>> stream
 xœ]RËnƒ0¼û+|L‘mI#!¤‚Ä¡•æˆ½PKÅXÆ9äï+{“TêV3žÖ»°ª­[£=en–x:h£,óÕI µ!"¡JKGñ-§ÞVµuw[<L­fR”²OõâÝ®j¾Àš°w§Ài3ÒÕ¹êÖ„uWk`ã)'eI„U¯½}ë' ,Ú6­ãµ¿mÎU÷§øºY IÄ»‘³‚Åö\oF çœ—´hš¦)	õï<C×eß½‹ê´¤ç	/#Ú#ÚF$êˆÒC@»S^Ò"ábsï	/¼çç&!0©Æ¤IŒOE$“%’’ÍCJVE2Å&Óc,9öšeI([ÌÌN(AÃöÉ<G•»ä~l9Ì(ìò¹ yuŒCãÖžÿ„mp…çb"¡Ê
@@ -1276,120 +1285,122 @@ endobj
 /Subtype /Type0
 /BaseFont /EAAAAA+LiberationSans-Italic
 /Encoding /Identity-H
-/DescendantFonts [103 0 R]
-/ToUnicode 104 0 R>>
+/DescendantFonts [105 0 R]
+/ToUnicode 106 0 R>>
 endobj
 xref
-0 105
+0 107
 0000000000 65535 f 
 0000000015 00000 n 
-0000031777 00000 n 
+0000032215 00000 n 
 0000000297 00000 n 
-0000041030 00000 n 
-0000049151 00000 n 
-0000063449 00000 n 
+0000041482 00000 n 
+0000049603 00000 n 
+0000063901 00000 n 
 0000000334 00000 n 
-0000078836 00000 n 
+0000079291 00000 n 
 0000000410 00000 n 
-0000091899 00000 n 
+0000092355 00000 n 
 0000000486 00000 n 
 0000000678 00000 n 
-0000000839 00000 n 
-0000000999 00000 n 
-0000001162 00000 n 
-0000001323 00000 n 
-0000001491 00000 n 
-0000001660 00000 n 
-0000001837 00000 n 
-0000002016 00000 n 
-0000002204 00000 n 
-0000002404 00000 n 
-0000002590 00000 n 
-0000002777 00000 n 
-0000002991 00000 n 
-0000003171 00000 n 
-0000003363 00000 n 
-0000003548 00000 n 
-0000003734 00000 n 
-0000003910 00000 n 
-0000004087 00000 n 
-0000004258 00000 n 
-0000004419 00000 n 
-0000004614 00000 n 
-0000004809 00000 n 
-0000004986 00000 n 
-0000005187 00000 n 
-0000005378 00000 n 
-0000005569 00000 n 
-0000005750 00000 n 
-0000005931 00000 n 
-0000006113 00000 n 
-0000006307 00000 n 
-0000006501 00000 n 
-0000006686 00000 n 
-0000006863 00000 n 
-0000007034 00000 n 
-0000007232 00000 n 
-0000007423 00000 n 
-0000007614 00000 n 
-0000007782 00000 n 
-0000007969 00000 n 
-0000008143 00000 n 
-0000008337 00000 n 
-0000008504 00000 n 
-0000008674 00000 n 
-0000032366 00000 n 
-0000020023 00000 n 
-0000020193 00000 n 
-0000020376 00000 n 
-0000020558 00000 n 
-0000020735 00000 n 
-0000020908 00000 n 
-0000021076 00000 n 
-0000021255 00000 n 
-0000021441 00000 n 
-0000021616 00000 n 
-0000021785 00000 n 
-0000021961 00000 n 
-0000022153 00000 n 
-0000022374 00000 n 
-0000022553 00000 n 
-0000022719 00000 n 
-0000022917 00000 n 
-0000023085 00000 n 
-0000023258 00000 n 
-0000023456 00000 n 
-0000023633 00000 n 
-0000023812 00000 n 
-0000023987 00000 n 
-0000024157 00000 n 
-0000024331 00000 n 
-0000032789 00000 n 
-0000032852 00000 n 
-0000032971 00000 n 
-0000039948 00000 n 
-0000040203 00000 n 
-0000040639 00000 n 
-0000041181 00000 n 
-0000048047 00000 n 
-0000048296 00000 n 
-0000048753 00000 n 
-0000049297 00000 n 
-0000061961 00000 n 
-0000062216 00000 n 
-0000063047 00000 n 
-0000063600 00000 n 
-0000077321 00000 n 
-0000077570 00000 n 
-0000078442 00000 n 
-0000078983 00000 n 
-0000090489 00000 n 
-0000090751 00000 n 
-0000091503 00000 n 
+0000000838 00000 n 
+0000000996 00000 n 
+0000001159 00000 n 
+0000001320 00000 n 
+0000001516 00000 n 
+0000001712 00000 n 
+0000001880 00000 n 
+0000002049 00000 n 
+0000002229 00000 n 
+0000002412 00000 n 
+0000002600 00000 n 
+0000002800 00000 n 
+0000002986 00000 n 
+0000003173 00000 n 
+0000003387 00000 n 
+0000003567 00000 n 
+0000003759 00000 n 
+0000003944 00000 n 
+0000004130 00000 n 
+0000004306 00000 n 
+0000004483 00000 n 
+0000004654 00000 n 
+0000004815 00000 n 
+0000005010 00000 n 
+0000005205 00000 n 
+0000005382 00000 n 
+0000005583 00000 n 
+0000005774 00000 n 
+0000005965 00000 n 
+0000006146 00000 n 
+0000006327 00000 n 
+0000006509 00000 n 
+0000006703 00000 n 
+0000006897 00000 n 
+0000007082 00000 n 
+0000007259 00000 n 
+0000007430 00000 n 
+0000007628 00000 n 
+0000007819 00000 n 
+0000008010 00000 n 
+0000008178 00000 n 
+0000008365 00000 n 
+0000008539 00000 n 
+0000008733 00000 n 
+0000008900 00000 n 
+0000009070 00000 n 
+0000032818 00000 n 
+0000020461 00000 n 
+0000020631 00000 n 
+0000020814 00000 n 
+0000020996 00000 n 
+0000021173 00000 n 
+0000021346 00000 n 
+0000021514 00000 n 
+0000021693 00000 n 
+0000021879 00000 n 
+0000022054 00000 n 
+0000022223 00000 n 
+0000022399 00000 n 
+0000022591 00000 n 
+0000022812 00000 n 
+0000022991 00000 n 
+0000023157 00000 n 
+0000023355 00000 n 
+0000023523 00000 n 
+0000023696 00000 n 
+0000023894 00000 n 
+0000024071 00000 n 
+0000024250 00000 n 
+0000024425 00000 n 
+0000024595 00000 n 
+0000024769 00000 n 
+0000033241 00000 n 
+0000033304 00000 n 
+0000033423 00000 n 
+0000040400 00000 n 
+0000040655 00000 n 
+0000041091 00000 n 
+0000041633 00000 n 
+0000048499 00000 n 
+0000048748 00000 n 
+0000049205 00000 n 
+0000049749 00000 n 
+0000062413 00000 n 
+0000062668 00000 n 
+0000063499 00000 n 
+0000064052 00000 n 
+0000077773 00000 n 
+0000078023 00000 n 
+0000078897 00000 n 
+0000079439 00000 n 
+0000090945 00000 n 
+0000091207 00000 n 
+0000091959 00000 n 
 trailer
-<</Size 105
-/Root 84 0 R
+<</Size 107
+/Root 86 0 R
 /Info 1 0 R>>
 startxref
-92055
+92511
 %%EOF

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -102,6 +102,9 @@ const formatYears = (years: number[]) =>
             <SocialIcon name="email" />
             <span>me<span aria-hidden="true">@</span>benjijang.com</span>
           </a>
+          <a href={externalLinks.scholar}>
+            <SocialIcon name="scholar" /> Scholar
+          </a>
           <a href={externalLinks.github}>
             <SocialIcon name="github" /> github.com/bstee615
           </a>

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -401,6 +401,7 @@ const formatYears = (years: number[]) =>
   .cv section > h2 {
     margin: 0 0 1rem;
     padding-bottom: 0.35rem;
+    border-bottom: var(--divider);
     font-size: 1.2rem;
     letter-spacing: 0.04em;
     text-transform: uppercase;


### PR DESCRIPTION
## Summary

- add the same horizontal divider beneath every web CV section heading
- add an icon-labeled Scholar link before GitHub in both the web and PDF CV contact rows
- regenerate the published two-page PDF

## Validation

- `npm run lint`
- `npm run build`
- `npm run build:cv`
- visual review of the regenerated PDF