### PR TITLE
Simplify CV PDF button

### DIFF
--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -116,10 +116,11 @@ const formatYears = (years: number[]) =>
         class="cv-pdf btn btn-secondary btn-sm"
         href="/files/benjamin-steenhoek-cv.pdf"
       >
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M5 2h9l5 5v15H5z"></path>
-          <path d="M14 2v5h5"></path>
-          <text class="cv-pdf__letters" x="7" y="17">PDF</text>
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            fill-rule="evenodd"
+            d="M14 4.5V14a2 2 0 0 1-2 2h-1v-1h1a1 1 0 0 0 1-1V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v9H2V2a2 2 0 0 1 2-2h5.5zM1.6 11.85H0v3.999h.791v-1.342h.803q.43 0 .732-.173.305-.175.463-.474a1.4 1.4 0 0 0 .161-.677q0-.375-.158-.677a1.2 1.2 0 0 0-.46-.477q-.3-.18-.732-.179m.545 1.333a.8.8 0 0 1-.085.38.57.57 0 0 1-.238.241.8.8 0 0 1-.375.082H.788V12.48h.66q.327 0 .512.181.185.183.185.522m1.217-1.333v3.999h1.46q.602 0 .998-.237a1.45 1.45 0 0 0 .595-.689q.196-.45.196-1.084 0-.63-.196-1.075a1.43 1.43 0 0 0-.589-.68q-.396-.234-1.005-.234zm.791.645h.563q.371 0 .609.152a.9.9 0 0 1 .354.454q.118.302.118.753a2.3 2.3 0 0 1-.068.592 1.1 1.1 0 0 1-.196.422.8.8 0 0 1-.334.252 1.3 1.3 0 0 1-.483.082h-.563zm3.743 1.763v1.591h-.79V11.85h2.548v.653H7.896v1.117h1.606v.638z"
+          ></path>
         </svg>
         PDF
       </a>
@@ -384,22 +385,9 @@ const formatYears = (years: number[]) =>
   }
 
   .cv-pdf svg {
-    width: 1.15rem;
-    height: 1.15rem;
-    fill: none;
-    stroke: currentColor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-width: 1.7;
-  }
-
-  .cv-pdf .cv-pdf__letters {
+    width: 1rem;
+    height: 1rem;
     fill: currentColor;
-    stroke: none;
-    font-family: var(--font-sans);
-    font-size: 5.25px;
-    font-weight: 800;
-    letter-spacing: -0.3px;
   }
 
   .cv section {

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -113,15 +113,9 @@ const formatYears = (years: number[]) =>
         </div>
       </div>
       <a
-        class="cv-pdf btn btn-secondary btn-sm"
+        class="btn btn-secondary btn-sm"
         href="/files/benjamin-steenhoek-cv.pdf"
       >
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path
-            fill-rule="evenodd"
-            d="M14 4.5V14a2 2 0 0 1-2 2h-1v-1h1a1 1 0 0 0 1-1V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v9H2V2a2 2 0 0 1 2-2h5.5zM1.6 11.85H0v3.999h.791v-1.342h.803q.43 0 .732-.173.305-.175.463-.474a1.4 1.4 0 0 0 .161-.677q0-.375-.158-.677a1.2 1.2 0 0 0-.46-.477q-.3-.18-.732-.179m.545 1.333a.8.8 0 0 1-.085.38.57.57 0 0 1-.238.241.8.8 0 0 1-.375.082H.788V12.48h.66q.327 0 .512.181.185.183.185.522m1.217-1.333v3.999h1.46q.602 0 .998-.237a1.45 1.45 0 0 0 .595-.689q.196-.45.196-1.084 0-.63-.196-1.075a1.43 1.43 0 0 0-.589-.68q-.396-.234-1.005-.234zm.791.645h.563q.371 0 .609.152a.9.9 0 0 1 .354.454q.118.302.118.753a2.3 2.3 0 0 1-.068.592 1.1 1.1 0 0 1-.196.422.8.8 0 0 1-.334.252 1.3 1.3 0 0 1-.483.082h-.563zm3.743 1.763v1.591h-.79V11.85h2.548v.653H7.896v1.117h1.606v.638z"
-          ></path>
-        </svg>
         PDF
       </a>
     </header>
@@ -382,12 +376,6 @@ const formatYears = (years: number[]) =>
     border-top: var(--divider);
     border-bottom: var(--divider);
     color: var(--muted);
-  }
-
-  .cv-pdf svg {
-    width: 1rem;
-    height: 1rem;
-    fill: currentColor;
   }
 
   .cv section {

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -117,13 +117,9 @@ const formatYears = (years: number[]) =>
         href="/files/benjamin-steenhoek-cv.pdf"
       >
         <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M6 2h8l4 4v16H6z"></path>
+          <path d="M5 2h9l5 5v15H5z"></path>
           <path d="M14 2v5h5"></path>
-          <path d="M8.5 16v-5h1.75a1.5 1.5 0 0 1 0 3H8.5"></path>
-          <path
-            d="M13 16v-5h1.25A1.75 1.75 0 0 1 16 12.75v1.5A1.75 1.75 0 0 1 14.25 16z"
-          ></path>
-          <path d="M17 16v-5h1.5M17 13.25h1.25"></path>
+          <text class="cv-pdf__letters" x="7" y="17">PDF</text>
         </svg>
         PDF
       </a>
@@ -388,13 +384,22 @@ const formatYears = (years: number[]) =>
   }
 
   .cv-pdf svg {
-    width: 1rem;
-    height: 1rem;
+    width: 1.15rem;
+    height: 1.15rem;
     fill: none;
     stroke: currentColor;
     stroke-linecap: round;
     stroke-linejoin: round;
     stroke-width: 1.7;
+  }
+
+  .cv-pdf .cv-pdf__letters {
+    fill: currentColor;
+    stroke: none;
+    font-family: var(--font-sans);
+    font-size: 5.25px;
+    font-weight: 800;
+    letter-spacing: -0.3px;
   }
 
   .cv section {


### PR DESCRIPTION
## Summary

- remove the PDF icon from the CV download button
- keep a clean, compact `PDF` text label

## Validation

- `npm run lint:code`
- `npm run build`