### PR TITLE
Use title case for publication action links

### DIFF
--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -524,7 +524,6 @@ const formatYears = (years: number[]) =>
     font-size: 0.68rem;
     font-weight: 550;
     text-decoration: none;
-    text-transform: uppercase;
   }
 
   .cv-columns {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -549,7 +549,6 @@ const publicationsByYear = Array.from(
     font-size: 0.82rem;
     font-weight: 550;
     text-decoration: none;
-    text-transform: uppercase;
   }
 
   .scholar-cta {


### PR DESCRIPTION
## Summary
- remove page-specific uppercase transformations from publication action links
- render Paper, Code, and other publication link labels consistently in title case

## Verification
- `npm run lint`
- `npm run build`
- visually checked homepage and CV publication links